### PR TITLE
Repeatablenewselect

### DIFF
--- a/core/fields/Field_Image.php
+++ b/core/fields/Field_Image.php
@@ -12,9 +12,9 @@ class Field_Image extends Field {
 		$this->default = null;
 	}
 
-	public function display() {
+	public function display($repeatable_template=false) {
 
-		//CMS::pprint_r ($this);
+		// repeatable template boolean initiated in Field_Repeatable.php if inside repeatable form
 
 		$required="";
 		if ($this->required) {$required=" required ";}
@@ -25,7 +25,12 @@ class Field_Image extends Field {
 			$repeatable_id_suffix='';
 		}
 		else {
-			$repeatable_id_suffix='{{repeatable_id_suffix}}'; // injected via JS at repeatable addition time
+			if ($repeatable_template) {
+				$repeatable_id_suffix='{{repeatable_id_suffix}}'; // injected via JS at repeatable addition time
+			}
+			else {
+				$repeatable_id_suffix = "_" . uniqid();
+			}
 			$this->id = $this->id . $repeatable_id_suffix;
 		}
 

--- a/core/fields/Field_Repeatable.php
+++ b/core/fields/Field_Repeatable.php
@@ -77,7 +77,7 @@ class Field_Repeatable extends Field {
 			?>
 			<div class='repeatable'><button type='button' onclick='this.closest(".repeatable").remove();' class='button btn pull-right is-warning remove_repeater'>-</button>
 			<?php
-			$this->form->display_front_end(); 
+			$this->form->display_front_end(true); // pass true here to let form know it's for template/repeatable
 			echo "</div>";
 			$repeatable_template->markup = ob_get_contents();
 			ob_end_clean(); // end temp buffering without outputting any of the form to browser / existing buffer

--- a/core/fields/Field_Select.php
+++ b/core/fields/Field_Select.php
@@ -13,7 +13,16 @@ class Field_Select extends Field {
 	}
 
 	public function display() {
-		//CMS::pprint_r($this);
+		// if id needs to be unique for scripting purposes, make sure replacement text inserted
+		// this will be replaced during repeatable template literal js injection when adding new
+		// repeatable form item
+		if ($this->in_repeatable_form===null) {
+			$repeatable_id_suffix='';
+		}
+		else {
+			$repeatable_id_suffix='{{repeatable_id_suffix}}'; // injected via JS at repeatable addition time
+			$this->id = $this->id . $repeatable_id_suffix;
+		}
 		$UpdateSelect = [];
 		$required="";
 		if ($this->required) {$required=" required ";}

--- a/core/form.php
+++ b/core/form.php
@@ -137,7 +137,7 @@ class Form {
 		}
 	}
 
-	public function display_front_end() {
+	public function display_front_end($repeatable_template=false) {
 		
 		// first make sure array added to name if required
 		$aftername='';
@@ -151,7 +151,7 @@ class Form {
 				$wrapclass = $field->wrapclass ?? "";
 				echo "<div class='{$wrapclass} form_field field field_id_{$field->id}'>";
 			}
-			$field->display();
+			$field->display($repeatable_template); // pass repeatable_template so it knows this is called for making js repeatable template
 			if (!property_exists($field,'nowrap')) {
 				echo "</div><!-- end field -->";
 			}

--- a/testrepeatform.json
+++ b/testrepeatform.json
@@ -27,6 +27,20 @@
 			"description":"Repeatable text fields 2."
 		},
 		{
+			"name":"sel",
+			"id":"sel",
+			"type":"Select",
+			"label":"Repeatable SlimSelect Select",
+			"required":false,
+			"description":"Repeatable select with slimselect.",
+			"slimselect":true,
+			"select_options":[
+				{"text":"ID","value":"id"},
+				{"text":"Ordering","value":"order"},
+				{"text":"Created Date","value":"created"}
+			]
+		},
+		{
 			"name":"testrepeattags",
 			"id":"testrepeattags",
 			"type":"TagMultiple",


### PR DESCRIPTION
This should fix existing HB Gallery widget (nobody noticed that if you go back into a saved gallery you can't choose a new image, only add new ones or delete old entries.... ) and also now gives unique ids for each repeatable-aware form field both on page load/rendering AND when adding new repeatable entries.