### PR TITLE
feat: add ability to change mode in db class

### DIFF
--- a/core/db.php
+++ b/core/db.php
@@ -46,14 +46,14 @@ class db {
 		return CMS::Instance()->pdo->lastInsertId();
 	}
 
-	public static function fetchall($query, $paramsarray=[]) {
+	public static function fetchall($query, $paramsarray=[], $options=[]) {
 		if (!is_array($paramsarray)) {
 			$paramsarray = array($paramsarray);
 		}
 		try {
 			$stmt = CMS::Instance()->pdo->prepare($query);
 			$stmt->execute($paramsarray);
-			$result = $stmt->fetchAll();
+			$result = $stmt->fetchAll($options["mode"]);
 		}
 		catch (\PDOException $e) {
 			if (Config::$debug) {
@@ -68,35 +68,17 @@ class db {
 	}
 
 	public static function fetchallcolumn($query, $paramsarray=[]) {
-		// fetch single col as array
-		if (!is_array($paramsarray)) {
-			$paramsarray = array($paramsarray);
-		}
-		try {
-			$stmt = CMS::Instance()->pdo->prepare($query);
-			$stmt->execute($paramsarray);
-			$result = $stmt->fetchAll(PDO::FETCH_COLUMN);
-		}
-		catch (\PDOException $e) {
-			if (Config::$debug) {
-				//print_r (debug_backtrace()); exit(0);
-				CMS::show_error("Error performing query: " . $e->getMessage());
-			}
-			else {
-				CMS::show_error("Database query error - turn on debug for more information.");
-			}
-		}
-		return $result;
+		return DB::fetchall($query, $paramsarray, ["mode"=>PDO::FETCH_COLUMN]);
 	}
 
-	public static function fetch($query, $paramsarray=[]) {
+	public static function fetch($query, $paramsarray=[], $options=[]) {
 		if (!is_array($paramsarray)) {
 			$paramsarray = array($paramsarray);
 		}
 		try {
 			$stmt = CMS::Instance()->pdo->prepare($query);
 			$stmt->execute($paramsarray);
-			$result = $stmt->fetch();
+			$result = $stmt->fetch($options["mode"]);
 		}
 		catch (\PDOException $e) {
 			if (Config::$debug) {


### PR DESCRIPTION
allows people to set the query mode from a db class call. see https://andrew.holtbosselabs.com/db_testing for output of the test suite. additionally, this pr forward thinks so that additional options can be added in the future (use of an array for the third arg)

```php
function dbdump($title, $data) {
    echo "<div style='border-bottom: 2px solid black;'>";
        echo "<p>$title</p>";
        CMS::pprint_r($data);
    echo "</div>";
}

echo "<div style='display: flex; gap: 1rem; flex-wrap: wrap;'>";
    dbdump("fetchall - no args", DB::fetchall("SELECT * FROM content WHERE 1"));
    dbdump("fetchall - pdo args", DB::fetchall("SELECT * FROM content WHERE state=?", [1]));
    dbdump("fetchall - pdo args, options: mode=>array", DB::fetchall("SELECT * FROM content WHERE state=?", [1], ["mode"=>PDO::FETCH_ASSOC]));
    dbdump("fetchall - pdo args, options: mode=>object", DB::fetchall("SELECT * FROM content WHERE state=?", [1], ["mode"=>PDO::FETCH_OBJ]));
echo "</div>";

echo "<div style='display: flex; gap: 1rem; flex-wrap: wrap;'>";
    dbdump("fetch - no args", DB::fetch("SELECT * FROM content WHERE id=2"));
    dbdump("fetch - pdo args", DB::fetch("SELECT * FROM content WHERE id=?", [2]));
    dbdump("fetch - pdo args, options: mode=>array", DB::fetch("SELECT * FROM content WHERE id=?", [2], ["mode"=>PDO::FETCH_ASSOC]));
    dbdump("fetch - pdo args, options: mode=>object", DB::fetch("SELECT * FROM content WHERE id=?", [2], ["mode"=>PDO::FETCH_OBJ]));
echo "</div>";

echo "<div style='display: flex; gap: 1rem; flex-wrap: wrap;'>";
    dbdump("fetchallcolumn - no args", DB::fetchallcolumn("SELECT * FROM content WHERE 1"));
    dbdump("fetchallcolumn - pdo args", DB::fetchallcolumn("SELECT * FROM content WHERE state=?", [1]));
echo "</div>";
```
