### PR TITLE
Imageformatmagic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,7 @@ admin/controllers/home/views
 admin/controllers/home/views/**
 #ignore non default controllers
 core/controllers/**
+!core/controllers/image/
+!core/controllers/image/**
 !controllers/image/
 !controllers/image/**

--- a/admin/controllers/images/views/show/model.php
+++ b/admin/controllers/images/views/show/model.php
@@ -2,7 +2,7 @@
 defined('CMSPATH') or die; // prevent unauthorized access
 
 $valid_image_types = [];
-foreach(File::get_image_types() as $type => $value) {
+foreach(File::$image_types as $type => $value) {
     array_push($valid_image_types, "'$type'");
 }
 

--- a/admin/controllers/images/views/uploadv2/model.php
+++ b/admin/controllers/images/views/uploadv2/model.php
@@ -12,7 +12,7 @@ if (CMS::Instance()->user->username=="guest") {
 	state 1: valid+thumbnails
 	state 2: valid+no thumbnails
 */
-$image_types_data = File::get_image_types();
+$image_types_data = File::$image_types;
 
 $uploaded_files_array = $_FILES['file-upload'];
 $alts = Input::getvar('alt','ARRAYOFSTRING');

--- a/core/controllers/image/controller.php
+++ b/core/controllers/image/controller.php
@@ -12,6 +12,11 @@ $req_width = $_GET['w'] ?? $segments[2];
 $req_format = $_GET['fmt'] ?? $segments[3];
 $req_quality = $_GET['q'] ?? 75;
 
+// check quality param - size/width checked elsewhere
+if (!is_numeric($req_quality)) {
+	http_response_code(406); 
+	exit(0);
+}
 
 function serve_file ($media_obj, $fullpath, $seconds_to_cache=31536000) {
 	$seconds_to_cache = $seconds_to_cache;

--- a/core/controllers/image/controller.php
+++ b/core/controllers/image/controller.php
@@ -117,10 +117,16 @@ if ($segsize==3||$segsize==4) {
 			}
 			// check to see if format is og
 			// assume format is original mimetype
+			// if format is given as original, then force mimetype to match og
 			$mimetype = $image->mimetype;
 			if ($segsize==4) {
 				$format = $segments[3];
-				$mimetype = File::get_mimetype_by_format($format);
+				if ($format=="original") {
+					$mimetype = $image->mimetype;
+				}
+				else {
+					$mimetype = File::get_mimetype_by_format($format);
+				}
 			}
 			if ($mimetype) {
 				// get size

--- a/core/controllers/image/controller.php
+++ b/core/controllers/image/controller.php
@@ -123,7 +123,6 @@ if ($segsize==3) {
 				serve_file ($image, $newsize_path);
 			}
 			elseif ($param=="web") {	
-				$original_path = CMSPATH . "/images/processed/" . $image->filename;
 				$newsize_path = CMSPATH . "/images/processed/web_" . $image->filename;
 				if ($image->width > 1920) {
 					if (!file_exists($newsize_path)) {

--- a/core/controllers/image/controller.php
+++ b/core/controllers/image/controller.php
@@ -30,7 +30,7 @@ function serve_file ($media_obj, $fullpath, $seconds_to_cache=31536000) {
 }
 
 
-function make_thumb ($src, $dest, $desired_width, $file, $quality=65, $newmimetype=false) {
+function make_thumb ($src, $dest, $desired_width, $file, $quality=70, $newmimetype=false) {
 	if (!$newmimetype) {
 		// no new format requested, simply use existing mimetype
 		$newmimetype = $image->mimetype;
@@ -57,7 +57,7 @@ function make_thumb ($src, $dest, $desired_width, $file, $quality=65, $newmimety
 		imagejpeg($virtual_image, $dest, $quality);
 	}
 	elseif ($newmimetype=='image/webp') {
-		imagewebp($virtual_image, $dest, $quality);
+		imagewebp($virtual_image, $dest, floor($quality*0.75));
 	}
 	else {
 		imagepng($virtual_image, $dest);

--- a/core/controllers/image/controller.php
+++ b/core/controllers/image/controller.php
@@ -116,7 +116,8 @@ if ($segsize>1 || ($req_width||$req_format||$req_quality<>75)) {
 			// get size
 			if (!is_numeric($req_width)) {
 				// get size from array lookup (web/thumb) - if fails, assume 1920
-				$size = File::$image_sizes[$req_width] ?? 1920;
+				$size = Image::$image_sizes[$req_width] ?? 1920;
+				CMS::log('Made image id ' . $image->id . ' with size: ' . $req_width . '(' . $size . ")");
 				if (!$size) {
 					http_response_code(406); // unknown size
 					exit(0);

--- a/core/controllers/image/controller.php
+++ b/core/controllers/image/controller.php
@@ -57,7 +57,7 @@ function make_thumb ($src, $dest, $desired_width, $file, $quality=65, $newmimety
 		imagejpeg($virtual_image, $dest, $quality);
 	}
 	elseif ($newmimetype=='image/webp') {
-		imagewebp($virtual_image, $dest);
+		imagewebp($virtual_image, $dest, $quality);
 	}
 	else {
 		imagepng($virtual_image, $dest);

--- a/core/controllers/image/controller.php
+++ b/core/controllers/image/controller.php
@@ -117,7 +117,6 @@ if ($segsize>1 || ($req_width||$req_format||$req_quality<>75)) {
 			if (!is_numeric($req_width)) {
 				// get size from array lookup (web/thumb) - if fails, assume 1920
 				$size = Image::$image_sizes[$req_width] ?? 1920;
-				CMS::log('Made image id ' . $image->id . ' with size: ' . $req_width . '(' . $size . ")");
 				if (!$size) {
 					http_response_code(406); // unknown size
 					exit(0);

--- a/core/file.php
+++ b/core/file.php
@@ -26,6 +26,17 @@ class File {
 		"image/gif" => 2
 	];
 
+	public static function get_mimetype_by_format($format) {
+		// return mimetype when passed partial match
+		// such as webp, jpeg or png
+		foreach (File::$image_types as $key => $value) {
+			if (strpos($key,$format)!==false) {
+				return $key;
+			}
+		}
+		return false;
+	}
+
 	function __construct($filepath="") {
 		$this->id = null;
 		$this->type = null;

--- a/core/file.php
+++ b/core/file.php
@@ -107,11 +107,4 @@ class File {
 	private function import_into_db() {
 	}
 
-	public static function get_image_types() {
-		
-		// TODO: remove all trace of this function and use static variable instead 
-		// e.g. File::$image_types
-
-		return $this->image_types;
-	}
 }

--- a/core/file.php
+++ b/core/file.php
@@ -11,8 +11,20 @@ class File {
 	public $alt;
 	public $filename;
 	public $mimetype;
-
 	
+	/*
+		state 0: invalid
+		state 1: valid+thumbnails
+		state 2: valid+no thumbnails
+	*/
+	public static $image_types = [
+		"image/jpeg" => 1,
+		"image/webp" => 1,
+		"image/png" => 1,
+		"image/svg+xml" => 2,
+		"image/svg" => 2,
+		"image/gif" => 2
+	];
 
 	function __construct($filepath="") {
 		$this->id = null;
@@ -40,7 +52,7 @@ class File {
 	}
 
 	public function is_image() {
-		if (File::get_image_types()[$this->mimetype] >= 0 ) {
+		if ($this->image_types[$this->mimetype] >= 0 ) {
 			return true;
 		}
 		else {
@@ -96,20 +108,10 @@ class File {
 	}
 
 	public static function get_image_types() {
-		/*
-			state 0: invalid
-			state 1: valid+thumbnails
-			state 2: valid+no thumbnails
-		*/
-		$image_types = [
-			"image/jpeg" => 1,
-			"image/webp" => 1,
-			"image/png" => 1,
-			"image/svg+xml" => 2,
-			"image/svg" => 2,
-			"image/gif" => 2
-		];
+		
+		// TODO: remove all trace of this function and use static variable instead 
+		// e.g. File::$image_types
 
-		return $image_types;
+		return $this->image_types;
 	}
 }

--- a/core/image.php
+++ b/core/image.php
@@ -31,7 +31,8 @@ class Image {
         }       
     }
     
-    public function render($size="original", $class="") {
+    public function render($size="original", $class="", $format="original") {
+        // TODO: allow system-wide pref for default image encoding
         // size should be original, web, or thumb 
         //echo "<img loading='lazy' class='{$class}' src='" . Config::$uripath . "/image/" . $this->id . "/" . $size . "' alt='{$this->alt}' title='{$this->title}'/>";
         echo "<img decode='async' width='{$this->width}' height='{$this->height}' loading='lazy' class='rendered_img {$class}' src='" . Config::$uripath . "/image/" . $this->id . "/" . $size . "' alt='{$this->alt}' title='{$this->title}'/>";

--- a/core/image.php
+++ b/core/image.php
@@ -9,6 +9,10 @@ class Image {
     public $title;
     public $alt;
     public $mimetype;
+    public static $image_sizes = [
+		"thumb"=>200,
+		"web"=>1920
+	];
     // modified also available, but almost certainly never needed front-end
     
     public function __construct($id) {


### PR DESCRIPTION
Allow fourth parameter in image controller URL for selecting format.

i.e. /image/12/800/webp

If omitted, assumes mimetype of originally saved image in db.

I know I balked at this suggestion from multiple sources originally, but, as usual, good ideas take time to settle in my brain.

Edit:

If omitted, may be nice to have a Config value to state preferred format if none given - could even ship with 'webp' as the default? Worth discussion at next LAL.