### PR TITLE
Shortcodes

### DIFF
--- a/core/cms.php
+++ b/core/cms.php
@@ -30,6 +30,7 @@ final class CMS {
 	private $core_controller = false;
 	private $need_session = true;
 	public $hooks = [];
+	public $shortcodes = [];
 	public $head_entries = []; // array of string to be output during CMSHEAD replacement
 	public $version = "2.4.77";
 

--- a/core/cms.php
+++ b/core/cms.php
@@ -621,6 +621,10 @@ final class CMS {
 				// save page contents to CMS
 				$this->page_contents = ob_get_contents();
 				ob_end_clean();
+				// execute shortcodes - before plugins, expect plugins will usually want to affect code output by shortcodes not other way round...
+				//if ($this->shortcodes) {
+					$this->page_contents = Shortcode::exec_all($this->page_contents);
+				//}
 				// perform content filtering / plugins on CMS::page_contents;
 				$this->page_contents = Hook::execute_hook_filters('content_ready_frontend', $this->page_contents);
 				// render CMS header - can incorporate changes to page title/og/metatags from content controllers

--- a/core/image.php
+++ b/core/image.php
@@ -31,12 +31,26 @@ class Image {
         }       
     }
     
-    public function render($size="original", $class="", $output_immediately=true, $attributes=[]) {
+    public function render($size="", $class="", $output_immediately=true, $attributes=[]) {
         // size and class used in v <= 2.4.77
+        // $w attribute supercedes $size
         // kept for back compat - class param and class passed via attribute are combined
         // handle attributes
         $class = $class . " " . ($attributes['class'] ?? ''); 
         $w = $attributes['w'] ?? null;
+        if (!$w) {
+            if ($size && !is_numeric($size)) {
+                // no w attribute, string size - figure out or default to 1920
+                $w = $this->image_sizes[$size] ?? '1920';
+            }
+            elseif ($size) {
+                // no $w attr, but got numeric $size
+                $w = $size;
+            }
+            else {
+                $w = $this->width; // default to og size if no $size or $w attr
+            }
+        }
         $q = $attributes['q'] ?? null;
         $fmt = $attributes['fmt'] ?? null;
         $loading = $attributes['loading'] ?? "lazy"; // use eager for headings

--- a/core/image.php
+++ b/core/image.php
@@ -31,10 +31,36 @@ class Image {
         }       
     }
     
-    public function render($size="original", $class="", $format="original") {
-        // TODO: allow system-wide pref for default image encoding
-        // size should be original, web, or thumb 
-        //echo "<img loading='lazy' class='{$class}' src='" . Config::$uripath . "/image/" . $this->id . "/" . $size . "' alt='{$this->alt}' title='{$this->title}'/>";
-        echo "<img decode='async' width='{$this->width}' height='{$this->height}' loading='lazy' class='rendered_img {$class}' src='" . Config::$uripath . "/image/" . $this->id . "/" . $size . "' alt='{$this->alt}' title='{$this->title}'/>";
+    public function render($size="original", $class="", $output_immediately=true, $attributes=[]) {
+        // handle attributes
+        $class = $attributes['class'] ?? '';
+        $w = $attributes['w'] ?? null;
+        $q = $attributes['q'] ?? null;
+        $fmt = $attributes['fmt'] ?? null;
+        $width_param = $this->width;
+        $height_param = $this->height;
+        if ($w && is_numeric($w)) {
+            if ($w < $this->width) {
+                $width_param = $w;
+                // scale height
+                $height_param = floor(($w/$this->width)*$this->height);
+            }
+        }
+
+        // build url
+        $url_domain_path = Config::$uripath . "/image/" . $this->id . "?";
+        $url_params = [];
+        if ($w) {$url_params['w'] = $w; }
+        if ($q) {$url_params['q'] = $q; }
+        if ($fmt) {$url_params['fmt'] = $fmt; }
+        $url_params_string = http_build_query($url_params);
+        $url = $url_domain_path . $url_params_string;
+        $markup = "<img decode='async' width='{$width_param}' height='{$height_param}' loading='lazy' class='rendered_img {$class}' src='".$url."' alt='{$this->alt}' title='{$this->title}'/>";
+        if ($output_immediately) {
+            echo $markup;
+        }
+        else {
+            return $markup;
+        }
     }
 }

--- a/core/image.php
+++ b/core/image.php
@@ -32,11 +32,14 @@ class Image {
     }
     
     public function render($size="original", $class="", $output_immediately=true, $attributes=[]) {
+        // size and class used in v <= 2.4.77
+        // kept for back compat - class param and class passed via attribute are combined
         // handle attributes
-        $class = $attributes['class'] ?? '';
+        $class = $class . " " . ($attributes['class'] ?? ''); 
         $w = $attributes['w'] ?? null;
         $q = $attributes['q'] ?? null;
         $fmt = $attributes['fmt'] ?? null;
+        $loading = $attributes['loading'] ?? "lazy"; // use eager for headings
         $width_param = $this->width;
         $height_param = $this->height;
         if ($w && is_numeric($w)) {
@@ -55,7 +58,7 @@ class Image {
         if ($fmt) {$url_params['fmt'] = $fmt; }
         $url_params_string = http_build_query($url_params);
         $url = $url_domain_path . $url_params_string;
-        $markup = "<img decode='async' width='{$width_param}' height='{$height_param}' loading='lazy' class='rendered_img {$class}' src='".$url."' alt='{$this->alt}' title='{$this->title}'/>";
+        $markup = "<img decode='async' width='{$width_param}' height='{$height_param}' loading='{$loading}' class='rendered_img {$class}' src='".$url."' alt='{$this->alt}' title='{$this->title}'/>";
         if ($output_immediately) {
             echo $markup;
         }

--- a/core/shortcode.php
+++ b/core/shortcode.php
@@ -15,13 +15,10 @@ class Shortcode {
         CMS::Instance()->shortcodes[$this->title] = $this;
     }
 
-    public static function get_shortcode_attributes_regex() {
-        return '/([\w-]+)\s*=\s*"([^"]*)"(?:\s|$)|([\w-]+)\s*=\s*\'([^\']*)\'(?:\s|$)|([\w-]+)\s*=\s*([^\s\'"]+)(?:\s|$)|"([^"]*)"(?:\s|$)|\'([^\']*)\'(?:\s|$)|(\S+)(?:\s|$)/'; 
-    }
-
     function shortcode_parse_attributes($attributes_text) {
         $attributes = [];
-        $pattern = Shortcode::get_shortcode_attributes_regex();
+        // regex @author: wordpress
+        $pattern = '/([\w-]+)\s*=\s*"([^"]*)"(?:\s|$)|([\w-]+)\s*=\s*\'([^\']*)\'(?:\s|$)|([\w-]+)\s*=\s*([^\s\'"]+)(?:\s|$)|"([^"]*)"(?:\s|$)|\'([^\']*)\'(?:\s|$)|(\S+)(?:\s|$)/'; 
         // remove zero width spaces if present 
         // see: http://stackoverflow.com/questions/11305797/remove-zero-width-space-characters-from-a-javascript-string
         $attributes_text = preg_replace( "/[\x{00a0}\x{200b}]+/u", ' ', $attributes_text);

--- a/core/shortcode.php
+++ b/core/shortcode.php
@@ -1,0 +1,29 @@
+<?php
+defined('CMSPATH') or die; // prevent unauthorized access
+
+class Shortcode {
+    public $title;
+	public $fn;
+
+    public function __construct($title, $function) {
+        $this->title = $title;
+        $this->fn = $function;
+        $this->register();
+    }
+
+    private function register() {
+        CMS::Instance()->shortcodes[] = $this;
+    }
+
+    public function exec_all($contents) {
+        foreach (CMS::Instance()->shortcodes as $sc) {
+            $contents = ($sc->fn)($contents);
+        }
+        return $contents;
+    }
+}
+
+// test shortcode
+$foo = new Shortcode("boo", function($contents, ...$args){
+    return $contents . "<h1>boo</h1>" ;
+});

--- a/core/shortcode.php
+++ b/core/shortcode.php
@@ -20,12 +20,13 @@ class Shortcode {
     }
 
     function shortcode_parse_attributes($attributes_text) {
-        // TODO: clean room implementation
         $attributes = [];
         $pattern = Shortcode::get_shortcode_attributes_regex();
-        $attributes_text = preg_replace( "/[\x{00a0}\x{200b}]+/u", ' ', $attributes_text );
-        if ( preg_match_all( $pattern, $attributes_text, $match, PREG_SET_ORDER ) ) {
-
+        // remove zero width spaces if present 
+        // see: http://stackoverflow.com/questions/11305797/remove-zero-width-space-characters-from-a-javascript-string
+        $attributes_text = preg_replace( "/[\x{00a0}\x{200b}]+/u", ' ', $attributes_text);
+        // @author: wordpress
+        if (preg_match_all( $pattern, $attributes_text, $match, PREG_SET_ORDER)) {
             foreach ( $match as $m ) {
                 if ( ! empty( $m[1] ) ) {
                     $attributes[ strtolower( $m[1] ) ] = stripcslashes( $m[2] );
@@ -41,56 +42,10 @@ class Shortcode {
                     $attributes[] = stripcslashes( $m[9] );
                 }
             }
-    
-            // Reject any unclosed HTML elements.
-            foreach ( $attributes as &$value ) {
-                if ( false !== strpos( $value, '<' ) ) {
-                    if ( 1 !== preg_match( '/^[^<]*+(?:<[^>]*+>[^<]*+)*+$/', $value ) ) {
-                        $value = '';
-                    }
-                }
-            }
         } else {
-            $attributes = ltrim( $text );
+            $attributes = ltrim($text);
         }
         return $attributes;
-    }
-
-    public static function get_shortcode_regex($tagnames=null) {
-        if (!$tagnames) {
-            // none passed, play safe and get all registered
-            $tagnames = CMS::Instance()->shortcode_tags;
-        }
-        // TODO: clean room implementation
-        $tagregexp = implode( '|', array_map( 'preg_quote', $tagnames ) );
-        return '\\['                             // Opening bracket.
-            . '(\\[?)'                           // 1: Optional second opening bracket for escaping shortcodes: [[tag]].
-            . "($tagregexp)"                     // 2: Shortcode name.
-            . '(?![\\w-])'                       // Not followed by word character or hyphen.
-            . '('                                // 3: Unroll the loop: Inside the opening shortcode tag.
-            .     '[^\\]\\/]*'                   // Not a closing bracket or forward slash.
-            .     '(?:'
-            .         '\\/(?!\\])'               // A forward slash not followed by a closing bracket.
-            .         '[^\\]\\/]*'               // Not a closing bracket or forward slash.
-            .     ')*?'
-            . ')'
-            . '(?:'
-            .     '(\\/)'                        // 4: Self closing tag...
-            .     '\\]'                          // ...and closing bracket.
-            . '|'
-            .     '\\]'                          // Closing bracket.
-            .     '(?:'
-            .         '('                        // 5: Unroll the loop: Optionally, anything between the opening and closing shortcode tags.
-            .             '[^\\[]*+'             // Not an opening bracket.
-            .             '(?:'
-            .                 '\\[(?!\\/\\2\\])' // An opening bracket not followed by the closing shortcode tag.
-            .                 '[^\\[]*+'         // Not an opening bracket.
-            .             ')*+'
-            .         ')'
-            .         '\\[\\/\\2\\]'             // Closing shortcode tag.
-            .     ')?'
-            . ')'
-            . '(\\]?)';                          // 6: Optional second closing brocket for escaping shortcodes: [[tag]].
     }
 
     public static function exec_all($contents) {
@@ -109,14 +64,17 @@ class Shortcode {
         if (!$required_shortcode_tags) {
             return $contents;
         }
-        $pattern = Shortcode::get_shortcode_regex($required_shortcode_tags);
+
+        $tagregexp = implode('|', array_map('preg_quote', $required_shortcode_tags));
+        // regex @author: wordpress
+        $pattern = '\\[(\[?)(' . $tagregexp . ')(?![\w-])([^\]\/]*(?:\/(?!\])[^\]\/]*)*?)(?:(\/)\]|\](?:([^\[]*+(?:\[(?!\/\2\])[^\[]*+)*+)\[\/\2\])?)(\]?)'; 
 	    $contents = preg_replace_callback( "/$pattern/", 'Shortcode::apply_shortcode', $contents );
         return $contents;
     }
 
     public static function apply_shortcode($match) {
         // escape double [[ ]]
-        if ( '[' === $match[1] && ']' === $match[6] ) {
+        if ('['===$match[1] && ']'===$match[6]) {
             return substr( $match[0], 1, -1 );
         }
         $title = $match[2];
@@ -127,7 +85,7 @@ class Shortcode {
     }
 }
 
-// test shortcode
+// core image shortcode
 $image_shortcode = new Shortcode("image", function($shortcode_content, $attributes, $title){
     $img = new Image($attributes['id']);
     if ($img) {

--- a/core/shortcode.php
+++ b/core/shortcode.php
@@ -6,24 +6,134 @@ class Shortcode {
 	public $fn;
 
     public function __construct($title, $function) {
-        $this->title = $title;
+        $this->title = $title; // must contain no spaces/special chars
         $this->fn = $function;
         $this->register();
     }
 
     private function register() {
-        CMS::Instance()->shortcodes[] = $this;
+        CMS::Instance()->shortcodes[$this->title] = $this;
     }
 
-    public function exec_all($contents) {
-        foreach (CMS::Instance()->shortcodes as $sc) {
-            $contents = ($sc->fn)($contents);
+    public static function get_shortcode_attributes_regex() {
+        return '/([\w-]+)\s*=\s*"([^"]*)"(?:\s|$)|([\w-]+)\s*=\s*\'([^\']*)\'(?:\s|$)|([\w-]+)\s*=\s*([^\s\'"]+)(?:\s|$)|"([^"]*)"(?:\s|$)|\'([^\']*)\'(?:\s|$)|(\S+)(?:\s|$)/'; 
+    }
+
+    function shortcode_parse_attributes($attributes_text) {
+        // TODO: clean room implementation
+        $attributes = [];
+        $pattern = Shortcode::get_shortcode_attributes_regex();
+        $attributes_text = preg_replace( "/[\x{00a0}\x{200b}]+/u", ' ', $attributes_text );
+        if ( preg_match_all( $pattern, $attributes_text, $match, PREG_SET_ORDER ) ) {
+
+            foreach ( $match as $m ) {
+                if ( ! empty( $m[1] ) ) {
+                    $attributes[ strtolower( $m[1] ) ] = stripcslashes( $m[2] );
+                } elseif ( ! empty( $m[3] ) ) {
+                    $attributes[ strtolower( $m[3] ) ] = stripcslashes( $m[4] );
+                } elseif ( ! empty( $m[5] ) ) {
+                    $attributes[ strtolower( $m[5] ) ] = stripcslashes( $m[6] );
+                } elseif ( isset( $m[7] ) && strlen( $m[7] ) ) {
+                    $attributes[] = stripcslashes( $m[7] );
+                } elseif ( isset( $m[8] ) && strlen( $m[8] ) ) {
+                    $attributes[] = stripcslashes( $m[8] );
+                } elseif ( isset( $m[9] ) ) {
+                    $attributes[] = stripcslashes( $m[9] );
+                }
+            }
+    
+            // Reject any unclosed HTML elements.
+            foreach ( $attributes as &$value ) {
+                if ( false !== strpos( $value, '<' ) ) {
+                    if ( 1 !== preg_match( '/^[^<]*+(?:<[^>]*+>[^<]*+)*+$/', $value ) ) {
+                        $value = '';
+                    }
+                }
+            }
+        } else {
+            $attributes = ltrim( $text );
         }
+        return $attributes;
+    }
+
+    public static function get_shortcode_regex($tagnames=null) {
+        if (!$tagnames) {
+            // none passed, play safe and get all registered
+            $tagnames = CMS::Instance()->shortcode_tags;
+        }
+        // TODO: clean room implementation
+        $tagregexp = implode( '|', array_map( 'preg_quote', $tagnames ) );
+        return '\\['                             // Opening bracket.
+            . '(\\[?)'                           // 1: Optional second opening bracket for escaping shortcodes: [[tag]].
+            . "($tagregexp)"                     // 2: Shortcode name.
+            . '(?![\\w-])'                       // Not followed by word character or hyphen.
+            . '('                                // 3: Unroll the loop: Inside the opening shortcode tag.
+            .     '[^\\]\\/]*'                   // Not a closing bracket or forward slash.
+            .     '(?:'
+            .         '\\/(?!\\])'               // A forward slash not followed by a closing bracket.
+            .         '[^\\]\\/]*'               // Not a closing bracket or forward slash.
+            .     ')*?'
+            . ')'
+            . '(?:'
+            .     '(\\/)'                        // 4: Self closing tag...
+            .     '\\]'                          // ...and closing bracket.
+            . '|'
+            .     '\\]'                          // Closing bracket.
+            .     '(?:'
+            .         '('                        // 5: Unroll the loop: Optionally, anything between the opening and closing shortcode tags.
+            .             '[^\\[]*+'             // Not an opening bracket.
+            .             '(?:'
+            .                 '\\[(?!\\/\\2\\])' // An opening bracket not followed by the closing shortcode tag.
+            .                 '[^\\[]*+'         // Not an opening bracket.
+            .             ')*+'
+            .         ')'
+            .         '\\[\\/\\2\\]'             // Closing shortcode tag.
+            .     ')?'
+            . ')'
+            . '(\\]?)';                          // 6: Optional second closing brocket for escaping shortcodes: [[tag]].
+    }
+
+    public static function exec_all($contents) {
+        $CMS = CMS::Instance();
+        // early checks for quick exits
+        if (!$CMS->shortcodes) {
+            return $contents;
+        }
+        if (strpos($contents, '[') === false) {
+            return $contents;
+        }
+        // find shortcode tags in content
+        // if none match registered shortcodes, another early exit
+        preg_match_all( '@\[([^<>&/\[\]\x00-\x20=]++)@', $contents, $matches );
+        $required_shortcode_tags = array_intersect( array_keys($CMS->shortcodes), $matches[1] );
+        if (!$required_shortcode_tags) {
+            return $contents;
+        }
+        $pattern = Shortcode::get_shortcode_regex($required_shortcode_tags);
+	    $contents = preg_replace_callback( "/$pattern/", 'Shortcode::apply_shortcode', $contents );
         return $contents;
+    }
+
+    public static function apply_shortcode($match) {
+        // escape double [[ ]]
+        if ( '[' === $match[1] && ']' === $match[6] ) {
+            return substr( $match[0], 1, -1 );
+        }
+        $title = $match[2];
+        $attributes = Shortcode::shortcode_parse_attributes($match[3]);
+        $shortcode_content = $match[5] ?? null;
+        $new_contents = (CMS::Instance()->shortcodes[$title]->fn)($shortcode_content, $attributes, $title);
+        return $new_contents;
     }
 }
 
 // test shortcode
-$foo = new Shortcode("boo", function($contents, ...$args){
-    return $contents . "<h1>boo</h1>" ;
+$image_shortcode = new Shortcode("image", function($shortcode_content, $attributes, $title){
+    $img = new Image($attributes['id']);
+    if ($img) {
+        return $img->render('web',$class, false, $attributes); // false - output immediately turned off to capture markup
+    }
+    else {
+        return "<span>&nbsp;Image Not Found&nbsp;</span>";
+    }
 });


### PR DESCRIPTION
**This requires some more testing before merging** - but would appreciate eyeballs on the code.

Quick description:

Allows for shortcodes in content areas.

e.g. This shortcode:
```
[image id=25 q=70 w=200 fmt=webp loading=lazy]
```
Will render image id correctly where this text is inside the markup of the page.

Think of it as poor mans plugin/widget hybrid - but easier to place within a page without having to create either a Hook or a new template position.

Will also update Wiki if this gets merged:

- Image class render function has two new parameters which will need explained (doesn't break back-compat)
- Shortcodes will need an explanation as well

Also need to discuss if we want to have a _functions.php_ style file for userspace shortcodes that CMS looks for to include - or just let people include them manually in their templates. (I prefer latter option, but having a single global file that is _known_ has some benefits too).

Future work will include making shortcode images appear somehow in the editor, as well as providing some sort of GUI to manipulate the values potentially.