### PR TITLE
Pagecaching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ core/controllers/**
 !core/controllers/image/**
 !controllers/image/
 !controllers/image/**
+cache/**

--- a/core/cache.php
+++ b/core/cache.php
@@ -1,0 +1,38 @@
+<?php
+defined('CMSPATH') or die; // prevent unauthorized access
+
+class Cache {
+    public function __construct() {
+        // make sure cache path exists
+        if (!is_dir(CMSPATH . "/cache")) {
+            mkdir(CMSPATH . "/cache", 0755);
+        }
+    }
+
+    private function gen_cache_filename($identifier, $type) {
+        return $type . "_" . hash('md4', $request);
+    }
+
+    public function url_cached($request) {
+        // checks if cached page exists and is older than cache
+        // TODO time check based on Config::$caching_time
+        $filename = $this->gen_cache_filename($request, 'url');
+        $fullpath = CMSPATH . "/cache/" . $filename;
+        if (file_exists($fullpath)) {
+            return $fullpath;
+        }
+        return false;
+    }
+
+    public function create_cache($identifier, $type, $content) {
+        $filename = $this->gen_cache_filename($request, 'url');
+        $fullpath = CMSPATH . "/cache/" . $filename;
+        file_put_contents($fullpath, $content);
+    }
+
+    public function serve_page($filepath) {
+        // todo: headers?
+        echo readfile($filepath);
+        exit();
+    }
+}

--- a/core/cache.php
+++ b/core/cache.php
@@ -14,12 +14,22 @@ class Cache {
     }
 
     public function url_cached($request) {
-        // checks if cached page exists and is older than cache
-        // TODO time check based on Config::$caching_time
+        // checks if cached file for a request exists and isn't stale
+        // if it's good, returns full path to cache file
+        // otherwise returns false
         $filename = $this->gen_cache_filename($request, 'url');
         $fullpath = CMSPATH . "/cache/" . $filename;
         if (file_exists($fullpath)) {
-            return $fullpath;
+            $curtime = time();
+            $cache_stale_time = 
+            $filetime = filemtime($fullpath);
+            if ($filetime && is_numeric($cache_stale_time)) {
+                $file_stale_time = $filetime + (Config::$cache['time'] * 60);
+                if ($file_stale_time <= $curtime) {
+                    // cache not stale yet
+                    return $fullpath;
+                }
+            }
         }
         return false;
     }

--- a/core/cache.php
+++ b/core/cache.php
@@ -29,6 +29,10 @@ class Cache {
                     // cache not stale yet
                     return $fullpath;
                 }
+                else {
+                    // cache is stale - delete file
+                    unlink($fullpath);
+                }
             }
         }
         return false;

--- a/core/cache.php
+++ b/core/cache.php
@@ -9,10 +9,14 @@ class Cache {
         }
     }
 
-    public function ignore($request) {
+    public function ignore($request, $type=null) {
         foreach (Config::$caching['ignore'] as $partial_path) {
             if (strpos($request, $partial_path)===0) {
                 // ignore
+                if ($type==='url') {
+                    // output nice message for full URL cache situation
+                    echo "<!-- Alba cache IGNORE -->\n";
+                }
                 return true;
             }
         } 
@@ -30,7 +34,7 @@ class Cache {
 
         // first check if path is ignored for urls
         if ($type=='url') {
-            if ($this->ignore($identifier)) {
+            if ($this->ignore($identifier, $type)) {
                 return false;
             }
         }
@@ -75,6 +79,7 @@ class Cache {
         if ($this->ignore($request)) {
             return false;
         }
+        echo "<!-- Alba cache: " . date('F j, Y, g:i a', filemtime($filepath)) . " -->\n";
         readfile($filepath);
         exit();
     }

--- a/core/cache.php
+++ b/core/cache.php
@@ -9,22 +9,32 @@ class Cache {
         }
     }
 
+    public function ignore($request) {
+        foreach (Config::$caching['ignore'] as $partial_path) {
+            if (strpos($request, $partial_path)===0) {
+                // ignore
+                return true;
+            }
+        } 
+    }
+
     private function gen_cache_filename($identifier, $type) {
         return $type . "_" . hash('md4', $identifier);
     }
 
-    public function url_cached($request) {
-        // checks if cached file for a request exists and isn't stale
+    public function is_cached($identifier, $type) {
+        // checks if cache file for an identifier/type exists 
+        // and that it isn't stale
         // if it's good, returns full path to cache file
         // otherwise returns false
-        // first check if path is ignored
-        foreach (Config::$caching['ignore'] as $partial_path) {
-            if (strpos($request, $partial_path)===0) {
-                // ignore
+
+        // first check if path is ignored for urls
+        if ($type=='url') {
+            if ($this->ignore($identifier)) {
                 return false;
             }
         }
-        $filename = $this->gen_cache_filename($request, 'url');
+        $filename = $this->gen_cache_filename($identifier, $type);
         $fullpath = CMSPATH . "/cache/" . $filename;
         if (file_exists($fullpath)) {
             $curtime = time();
@@ -44,14 +54,27 @@ class Cache {
         return false;
     }
 
-    public function create_cache($identifier, $type, $content) {
-        $filename = $this->gen_cache_filename($identifier, 'url');
+    public function create_cache($identifier, $type='url', $content="") {
+        // content agnostic - type commonly 'url' for full page
+        // but can be extended to create cache for anything
+        $filename = $this->gen_cache_filename($identifier, $type);
         $fullpath = CMSPATH . "/cache/" . $filename;
         file_put_contents($fullpath, $content);
     }
 
+    public function get_cache($filepath) {
+        return file_get_contents($filepath);
+    }
+
+    public function serve_cache($filepath) {
+        readfile($filepath);
+    }
+
     public function serve_page($filepath) {
         // todo: headers?
+        if ($this->ignore($request)) {
+            return false;
+        }
         readfile($filepath);
         exit();
     }

--- a/core/cache.php
+++ b/core/cache.php
@@ -21,10 +21,9 @@ class Cache {
         $fullpath = CMSPATH . "/cache/" . $filename;
         if (file_exists($fullpath)) {
             $curtime = time();
-            $cache_stale_time = 
             $filetime = filemtime($fullpath);
-            if ($filetime && is_numeric($cache_stale_time)) {
-                $file_stale_time = $filetime + (Config::$cache['time'] * 60);
+            $file_stale_time = $filetime + (Config::$cache['time'] * 60);
+            if ($filetime && is_numeric($file_stale_time)) {
                 if ($file_stale_time <= $curtime) {
                     // cache not stale yet
                     return $fullpath;

--- a/core/cache.php
+++ b/core/cache.php
@@ -10,7 +10,7 @@ class Cache {
     }
 
     private function gen_cache_filename($identifier, $type) {
-        return $type . "_" . hash('md4', $request);
+        return $type . "_" . hash('md4', $identifier);
     }
 
     public function url_cached($request) {
@@ -25,7 +25,7 @@ class Cache {
     }
 
     public function create_cache($identifier, $type, $content) {
-        $filename = $this->gen_cache_filename($request, 'url');
+        $filename = $this->gen_cache_filename($identifier, 'url');
         $fullpath = CMSPATH . "/cache/" . $filename;
         file_put_contents($fullpath, $content);
     }

--- a/core/cache.php
+++ b/core/cache.php
@@ -22,7 +22,7 @@ class Cache {
         if (file_exists($fullpath)) {
             $curtime = time();
             $filetime = filemtime($fullpath);
-            $file_stale_time = $filetime + (Config::$cache['time'] * 60);
+            $file_stale_time = $filetime + (Config::$caching['time'] * 60);
             if ($filetime && is_numeric($file_stale_time)) {
                 if ($file_stale_time <= $curtime) {
                     // cache not stale yet

--- a/core/cache.php
+++ b/core/cache.php
@@ -17,6 +17,13 @@ class Cache {
         // checks if cached file for a request exists and isn't stale
         // if it's good, returns full path to cache file
         // otherwise returns false
+        // first check if path is ignored
+        foreach (Config::$caching['ignore'] as $partial_path) {
+            if (strpos($request, $partial_path)===0) {
+                // ignore
+                return false;
+            }
+        }
         $filename = $this->gen_cache_filename($request, 'url');
         $fullpath = CMSPATH . "/cache/" . $filename;
         if (file_exists($fullpath)) {
@@ -24,7 +31,7 @@ class Cache {
             $filetime = filemtime($fullpath);
             $file_stale_time = $filetime + (Config::$caching['time'] * 60);
             if ($filetime && is_numeric($file_stale_time)) {
-                if ($file_stale_time <= $curtime) {
+                if ($file_stale_time > $curtime) {
                     // cache not stale yet
                     return $fullpath;
                 }
@@ -45,7 +52,7 @@ class Cache {
 
     public function serve_page($filepath) {
         // todo: headers?
-        echo readfile($filepath);
+        readfile($filepath);
         exit();
     }
 }

--- a/core/cms.php
+++ b/core/cms.php
@@ -215,7 +215,8 @@ final class CMS {
 			$this->need_session=false; // don't need session for image api
 		}
 
-		if (Config::$caching ?? null) {
+		if (Config::$caching ?? null && !ADMINPATH) {
+			// admin will never create caches, so no point in even checking
 			$this->cache = new Cache();
 			$page_file = $this->cache->url_cached($request);
 			if ($page_file) {

--- a/core/cms.php
+++ b/core/cms.php
@@ -218,9 +218,9 @@ final class CMS {
 		if (Config::$caching ?? null && !ADMINPATH) {
 			// admin will never create caches, so no point in even checking
 			$this->cache = new Cache();
-			$page_file = $this->cache->url_cached($request);
-			if ($page_file) {
-				$this->cache->serve_page($page_file);
+			$cached_page_file = $this->cache->is_cached($request, 'url');
+			if ($cached_page_file) {
+				$this->cache->serve_page($cached_page_file);
 			}
 		}
 
@@ -660,7 +660,7 @@ final class CMS {
 
 				// create full page cache if needed
 				if (Config::$caching ?? null) {
-					$this->cache->create_cache($_SERVER['REQUEST_URI'], 'url',$this->page_contents);
+					$this->cache->create_cache($_SERVER['REQUEST_URI'], 'url', $this->page_contents);
 				}
 			}	
 			

--- a/core/cms.php
+++ b/core/cms.php
@@ -659,7 +659,7 @@ final class CMS {
 
 				// create full page cache if needed
 				if (Config::$caching ?? null) {
-					$this->cache->create_cache($request,'url',$this->page_contents);
+					$this->cache->create_cache($_SERVER['REQUEST_URI'], 'url',$this->page_contents);
 				}
 			}	
 			

--- a/core/cms.php
+++ b/core/cms.php
@@ -215,6 +215,14 @@ final class CMS {
 			$this->need_session=false; // don't need session for image api
 		}
 
+		if (Config::$caching ?? null) {
+			$this->cache = new Cache();
+			$page_file = $this->cache->url_cached($request);
+			if ($page_file) {
+				$this->cache->serve_page($page_file);
+			}
+		}
+
 		// db
 		// TODO: move all db setup to db.php - make it not a class, just a old fashioned include
 		$dsn = "mysql:host=" . Config::$dbhost . ";dbname=" . Config::$dbname . ";charset=" . Config::$dbchar;
@@ -648,6 +656,11 @@ final class CMS {
 				}
 				// output final content
 				echo $this->page_contents;
+
+				// create full page cache if needed
+				if (Config::$caching ?? null) {
+					$this->cache->create_cache($request,'url',$this->page_contents);
+				}
 			}	
 			
 		}


### PR DESCRIPTION
Simple caching mechanism now in place. For now only used for full-page caching, but helps tremendously on pages where DB calls are a little sluggish but don't have to be immediately up-to-date. (Looking at you Starks).

Speaking of Starks - as well as being the reason I worked on this - they were used for testing too - see https://starks.holtbosselabs.com

***

Caching is only used if the $caching variable is present in _config.php_

```php
static $caching = [
    "type" => "fullpage",
    "time" => 15,
    "ignore" => ["/contact-us"]
];
```

"type" isn't used yet - but future work will enable either module-only caching, controller-only or a combination. This would enable smaller cache files/storage, and per-entity cache times etc.

"time" - time in minutes max cache time. 

"ignore" - array of URI partial matches to be ignore by caching system. currently checks for string being at START of URL, so a whole blog can be uncached if ignore array entry just has "/blog".  

***

Pages where dynamic values are **required**, such as recaptcha fields, API endpoints etc  should _never_ be cached or they won't work as expected, or at all.

Cached files are stored in webroot/cache, and are named with a type prefix and a hashed version of whatever unique resource identifier was used to generate them.

e.g. 
/cache/url_3ecf5d9f4e82b22c5dc5c95e2de39018

***

A note is injected for URL caches before either page is generated or served from cache noting cache status.

Ignored cache hits:

![image](https://user-images.githubusercontent.com/23583515/189484438-4ddffe61-d153-4b3c-91cc-417ac0c4519d.png)

Served cache hits:

![image](https://user-images.githubusercontent.com/23583515/189484467-4e923fb3-43ea-4577-a98f-8598d1fbf899.png)
