### PR TITLE
Editortweaks

### DIFF
--- a/core/fields/Field_Rich.php
+++ b/core/fields/Field_Rich.php
@@ -222,6 +222,12 @@ class Field_Rich extends Field {
 					modal.innerHTML = modal_html;
 					document.body.appendChild(modal);
 
+					// make first model input focus
+					let first_input = modal.querySelector('input');
+					if (first_input) {
+						first_input.focus();
+					}
+
 					// listener for modal
 					modal.addEventListener('click', function(e){
 						e.preventDefault();

--- a/core/fields/Field_Rich.php
+++ b/core/fields/Field_Rich.php
@@ -109,13 +109,12 @@ class Field_Rich extends Field {
 				
 				// move markup to hidden textarea on input
 				document.querySelector('#editor_for_<?php echo $this->name;?>').addEventListener('input',function(e){
-					//console.log('updating textarea for editor');
-					raw = e.target.innerHTML;
-					document.querySelector('#<?php echo $this->name;?>').innerText = raw;
+					raw = e.target.innerHTML; 
+					textarea = document.querySelector('#<?php echo $this->name;?>');
+					textarea.value = raw; console.log(textarea);
 				});
 				// move textarea to markup in editable on any change
 				document.querySelector('#<?php echo $this->id;?>').addEventListener('input',function(e){
-					//console.log('updating textarea for editor');
 					raw = e.target.value;
 					document.querySelector('#editor_for_<?php echo $this->name;?>').innerHTML = raw;
 				});
@@ -230,7 +229,10 @@ class Field_Rich extends Field {
 						function closeModal() {
 							modal = e.target.closest('.modal.is-active');
 							parent = modal.parentNode;
-							parent.removeChild(modal);							
+							parent.removeChild(modal);	
+							// update editor raw textarea with changes
+							let markup = document.querySelector('#editor_for_<?php echo $this->name;?>').innerHTML;
+							document.querySelector('#<?php echo $this->name;?>').value = markup;
 						}
 
 						switch (e.target.dataset.modalAction) {

--- a/core/fields/Field_Rich.php
+++ b/core/fields/Field_Rich.php
@@ -107,14 +107,14 @@ class Field_Rich extends Field {
 
 			document.addEventListener("DOMContentLoaded", function(){
 				
-				// move markup to hidden textarea on blur
-				document.querySelector('#editor_for_<?php echo $this->name;?>').addEventListener('blur',function(e){
+				// move markup to hidden textarea on input
+				document.querySelector('#editor_for_<?php echo $this->name;?>').addEventListener('input',function(e){
 					//console.log('updating textarea for editor');
 					raw = e.target.innerHTML;
 					document.querySelector('#<?php echo $this->name;?>').innerText = raw;
 				});
-				// move textarea to markup in editable on blur
-				document.querySelector('#<?php echo $this->id;?>').addEventListener('blur',function(e){
+				// move textarea to markup in editable on any change
+				document.querySelector('#<?php echo $this->id;?>').addEventListener('input',function(e){
 					//console.log('updating textarea for editor');
 					raw = e.target.value;
 					document.querySelector('#editor_for_<?php echo $this->name;?>').innerHTML = raw;

--- a/core/fields/Field_Rich.php
+++ b/core/fields/Field_Rich.php
@@ -111,7 +111,7 @@ class Field_Rich extends Field {
 				document.querySelector('#editor_for_<?php echo $this->name;?>').addEventListener('input',function(e){
 					raw = e.target.innerHTML; 
 					textarea = document.querySelector('#<?php echo $this->name;?>');
-					textarea.value = raw; console.log(textarea);
+					textarea.value = raw; 
 				});
 				// move textarea to markup in editable on any change
 				document.querySelector('#<?php echo $this->id;?>').addEventListener('input',function(e){

--- a/core/fields/Field_Rich.php
+++ b/core/fields/Field_Rich.php
@@ -222,7 +222,7 @@ class Field_Rich extends Field {
 					modal.innerHTML = modal_html;
 					document.body.appendChild(modal);
 
-					// make first model input focus
+					// make first modal input focus
 					let first_input = modal.querySelector('input');
 					if (first_input) {
 						first_input.focus();


### PR DESCRIPTION
Applies the following changes/fixes:

- Keep WYSIWYG editor and raw markup textarea in synch after each keypress OR modal operation instead of on blur. Hopefully fixes bug Josh was having repeatedly.
- If WYSIWYG modal contains an input field, it will receive focus after modal is generated.