### PR TITLE
feat: switch to tab with error if present

### DIFF
--- a/admin/templates/clean/js/script.js
+++ b/admin/templates/clean/js/script.js
@@ -114,10 +114,14 @@ let alltabs = document.querySelectorAll('.tabs');
 alltabs.forEach(tabs => {
 	let closest_wrap = tabs.closest('.tabs-wrap');
 	let content_wrap = closest_wrap.querySelector('.tab-content-start');
-	// set first tab active
-	tabs.querySelector('li').classList.add('is-active');
-	// set first content active
-	content_wrap.querySelector('.tab-content').classList.add('is-active');
+	// set first tab active - check to make sure no existing active items from invalid checks
+	if(!tabs.querySelector(".is-active")) {
+		tabs.querySelector('li').classList.add('is-active');
+	}
+	// set first content active - check to make sure no existing active items from invalid checks
+	if(!content_wrap.querySelector('.is-active')) {
+		content_wrap.querySelector('.tab-content').classList.add('is-active');
+	}
 	
 	// click event handler for tab headings
 	tabs.querySelectorAll('li').forEach(tab => {

--- a/core/fields/Field_Tab.php
+++ b/core/fields/Field_Tab.php
@@ -27,7 +27,20 @@ class Field_Tab extends Field {
 				<div  class='tab-content-start'>
 			<?php elseif ($this->mode=="tabscontentend"):?>
 				</div> <!-- end tabs -->
+				<div class="<?php $tabidentiferpoint="tabidentiferpoint_" . uniqid(); echo $tabidentiferpoint; ?>"></div>
 				</div> <!-- end tabs-wrap -->
+				<script>
+					let tabidentiferpoint = document.querySelector(".<?php echo $tabidentiferpoint; ?>").previousElementSibling;
+					let tabheader = tabidentiferpoint.previousElementSibling;
+					let invalidelement = tabidentiferpoint.querySelector(':invalid');
+					if(invalidelement) {
+						//set tab content to active
+						invalidelement.closest(".tab-content").classList.add("is-active");
+						//set tab header to active
+						let index = Array.prototype.indexOf.call(tabidentiferpoint.querySelectorAll(".tab-content"), invalidelement.closest(".tab-content"));
+						tabheader.querySelectorAll("li")[index].classList.add("is-active");
+					}
+				</script>
 			<?php elseif ($this->mode=="tabstart"):?>
 				<div  class='<?php echo $this->tabsid;?>-tab-content tab-content'>
 			<?php elseif ($this->mode=="tabend"):?>

--- a/core/fields/Field_Tab.php
+++ b/core/fields/Field_Tab.php
@@ -30,6 +30,7 @@ class Field_Tab extends Field {
 				<div class="<?php $tabidentiferpoint="tabidentiferpoint_" . uniqid(); echo $tabidentiferpoint; ?>"></div>
 				</div> <!-- end tabs-wrap -->
 				<script>
+					//handle page load
 					let tabidentiferpoint = document.querySelector(".<?php echo $tabidentiferpoint; ?>").previousElementSibling;
 					let tabheader = tabidentiferpoint.previousElementSibling;
 					let invalidelement = tabidentiferpoint.querySelector(':invalid');
@@ -40,6 +41,20 @@ class Field_Tab extends Field {
 						let index = Array.prototype.indexOf.call(tabidentiferpoint.querySelectorAll(".tab-content"), invalidelement.closest(".tab-content"));
 						tabheader.querySelectorAll("li")[index].classList.add("is-active");
 					}
+
+					//handle users invalid fields they set
+					tabidentiferpoint.addEventListener("invalid", (e)=>{
+						if(!e.target.closest(".tab-content").classList.contains("is-active")) { //we only care about non visible invalids
+							//handle tab
+							tabidentiferpoint.querySelector(".is-active").classList.remove("is-active");
+							e.target.closest(".tab-content").classList.add("is-active");
+
+							//handle header
+							tabheader.querySelector(".is-active").classList.remove("is-active");
+							let index = Array.prototype.indexOf.call(tabidentiferpoint.querySelectorAll(".tab-content"), e.target.closest(".tab-content"));
+							tabheader.querySelectorAll("li")[index].classList.add("is-active");
+						}
+					}, true);
 				</script>
 			<?php elseif ($this->mode=="tabstart"):?>
 				<div  class='<?php echo $this->tabsid;?>-tab-content tab-content'>


### PR DESCRIPTION
see title - also done in a repeatable element friendly fashion

how to test:
checkout this pr, make sure your paganation is set to something over 100, save it
apply bobs broken commit https://github.com/HoltBosse/Alba/commit/32a4c7176ff70fb5321ecc7675d68dab56e885b3
try to save again, notice it properly switches to the tab with the error. observe no more warnings in the console about unfocusable elements.
