### PR TITLE
init: content and tag save hooks started

### DIFF
--- a/core/category.php
+++ b/core/category.php
@@ -131,6 +131,7 @@ class Category {
 			CMS::Instance()->queue_message($error_text,'danger', $return_url);
 		}
 		else {
+			Hook::execute_hook_actions('on_category_save', $this);
 			CMS::Instance()->queue_message('Saved category','success', $return_url);
 		}
 	}

--- a/core/tag.php
+++ b/core/tag.php
@@ -168,6 +168,7 @@ class Tag {
 				foreach ($this->contenttypes as $contenttype) {
 					DB::exec('insert into tag_content_type (tag_id,content_type_id) values (?,?)', array($this->id, $contenttype));
 				}
+				Hook::execute_hook_actions('on_tag_save', $this);
 				CMS::Instance()->queue_message('Tag updated','success',Config::$uripath . '/admin/tags/show');	
 			}
 			else {
@@ -192,6 +193,8 @@ class Tag {
 				foreach ($this->contenttypes as $contenttype) {
 					DB::exec('insert into tag_content_type (tag_id,content_type_id) values (?,?)', array($new_id, $contenttype));
 				}
+				$this->id = $new_id;
+				Hook::execute_hook_actions('on_tag_save', $this);
 				CMS::Instance()->queue_message('New tag saved','success',Config::$uripath . '/admin/tags/');	
 			}
 			else {


### PR DESCRIPTION
Plugin for testing:

Folder: clear_cache_on_save

plugin_class.php

```php
<?php
defined('CMSPATH') or die; // prevent unauthorized access

class Plugin_clear_cache_on_save extends Plugin {
    public function init() {
        CMS::add_action("on_content_save", $this, 'clear_cache');
        CMS::add_action("on_tag_save", $this, 'clear_cache');
        CMS::add_action("on_category_save", $this, 'clear_cache');
    }

    public function clear_cache($args) {
        $cache_available = property_exists('Config','caching');
        if ($cache_available) {
            // clear cache
            $fileSystemIterator = new FilesystemIterator(CMSPATH . '/cache');
            foreach ($fileSystemIterator as $file) {
                unlink(CMSPATH . '/cache/'.$file->getFilename());
            }
            // CMS::log('Cache cleared by clear cache on save plugin');
        }
        else {
            // CMS::log('Cache not cleared by clear cache on save plugin, caching not enabled');
        }
    }
}
```

plugin_config.json
```json
{
	"title":"Clear Cache",
	"location":"clear_cache_on_save",
	"id":"clear_cache",
    "description":"Clear cache on save of content/tag/category",
    "version":"1.0",
    "author":"Bob Mitchell",
    "website":"https://holtbosse.com",
	"fields":[
	]
}
```