### PR TITLE
feat: fixes vertically uncentered state button

### DIFF
--- a/admin/controllers/categories/views/all/view.php
+++ b/admin/controllers/categories/views/all/view.php
@@ -66,18 +66,14 @@ table.dragging tr.droppable.ready {
 	background:rgba(155,255,100,0.3);
 }
 .drag_td {
-	display:flex;
-	
+	height: 0;
 }
-.before_after_wrap {
-	margin-right:0rem;
-	transition:all 0.3s ease;
-	/* margin-left:1rem; */
-	/* display:none; */
-	width:0;
-	opacity:0;
+.center_state {
+	height: 100%;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
 }
-
 .order_drop {
 	color: white;
     background: #aad;
@@ -195,6 +191,7 @@ table.dragging .before_after_wrap {
 				<?php CMS::Instance()->listing_content_id = $content_item->id; ?>
 				<tr id='row_id_<?php echo $content_item->id;?>' data-itemid="<?php echo $content_item->id;?>" data-ordering="<?php echo $content_item->ordering;?>" class='content_admin_row'>
 					<td class='drag_td'>
+					<div class="center_state">
 						<input class='hidden_multi_edit' type='checkbox' name='id[]' value='<?php echo $content_item->id; ?>'/>
 						<?php if ($order_by && $content_type_filter):?>
 						<div draggable="true"  data-itemid="<?php echo $content_item->id;?>" data-ordering="<?php echo $content_item->ordering;?>"  ondragend="dragend_handler(event)" ondragstart="dragstart_handler(event)" class="grip"><i class="fas fa-grip-lines"></i></div>
@@ -204,14 +201,15 @@ table.dragging .before_after_wrap {
 						</div>
 						<?php endif; ?>
 						<button class='button' type='submit' formaction='<?php echo Config::uripath();?>/admin/categories/action/toggle' name='id[]' value='<?php echo $content_item->id; ?>'>
-							<?php 
-							if ($content_item->state==1) { 
+							<?php
+							if ($content_item->state==1) {
 								echo '<i class="state1 is-success fas fa-check-circle" aria-hidden="true"></i>';
 							}
 							else {
 								echo '<i class="state0 fas fa-times-circle" aria-hidden="true"></i>';
 							} ?>
 						</button>
+						</div>
 					</td>
 					<td>
 						<?php $title_prefix="";

--- a/admin/controllers/content/views/all/view.php
+++ b/admin/controllers/content/views/all/view.php
@@ -66,8 +66,13 @@ table.dragging tr.droppable.ready {
 	background:rgba(155,255,100,0.3);
 }
 .drag_td {
-	display:flex;
-	
+	height: 0;
+}
+.center_state {
+	height: 100%;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
 }
 .before_after_wrap {
 	margin-right:0rem;
@@ -305,6 +310,7 @@ table.dragging .before_after_wrap {
 				<?php CMS::Instance()->listing_content_id = $content_item->id; ?>
 				<tr id='row_id_<?php echo $content_item->id;?>' data-itemid="<?php echo $content_item->id;?>" data-ordering="<?php echo $content_item->ordering;?>" class='content_admin_row'>
 					<td class='drag_td'>
+					<div class="center_state">
 						<input class='hidden_multi_edit' type='checkbox' name='id[]' value='<?php echo $content_item->id; ?>'/>
 						<?php if ($order_by && $content_type_filter):?>
 						<div draggable="true"  data-itemid="<?php echo $content_item->id;?>" data-ordering="<?php echo $content_item->ordering;?>"  ondragend="dragend_handler(event)" ondragstart="dragstart_handler(event)" class="grip"><i class="fas fa-grip-lines"></i></div>
@@ -322,6 +328,7 @@ table.dragging .before_after_wrap {
 								echo '<i class="state0 fas fa-times-circle" aria-hidden="true"></i>';
 							} ?>
 						</button>
+						</div>
 					</td>
 					<td>
 						<a href="<?php echo Config::uripath(); ?>/admin/content/edit/<?php echo $content_item->id;?>"><?php echo $content_item->title; ?></a>


### PR DESCRIPTION
Tired of the state section/publish button in admin tables looking like this?

![image](https://user-images.githubusercontent.com/60198052/204908576-b38e5805-acb2-4cd6-98fe-7d4591abc723.png)

Me too. So now they look like this:

![image](https://user-images.githubusercontent.com/60198052/204908758-23ac5267-be69-4a1b-950e-2f4e00e8ade2.png)