### PR TITLE
fix: installer error __callStatic function not copied into new config

### DIFF
--- a/configTESTBACKUP.php
+++ b/configTESTBACKUP.php
@@ -1,27 +1,27 @@
 <?php
-
 defined('CMSPATH') or die; // prevent unauthorized access 
 
- class Config {
+class Config {
 
-static $dbhost = 'localhost';
-static $dbname = 'dbname';
-static $dbuser = 'dbuser';
-static $dbpass = 'dbpass';
-static $dbchar = 'utf8mb4';
-static $sitename = "Alba";
-static $uripath = "";
-static $debug = false;
-static $domain = 'auto';
-static $user_core_controllers = NULL;
-static $admintemplate = 'clean';
-static $frontendlogin = false;
-static $environment = "dev"; // dev/staging/live
-static $channel = "stable"; // stable/alpha
-static $updatedomain = "alba.holtbosse.com";
-static $dev_banner = false;
+    static $dbhost = 'localhost';
+    static $dbname = 'dbname';
+    static $dbuser = 'dbuser';
+    static $dbpass = 'dbpass';
+    static $dbchar = 'utf8mb4';
+    static $sitename = "Alba";
+    static $uripath = "";
+    static $debug = false;
+    static $domain = 'auto';
+    static $user_core_controllers = NULL;
+    static $admintemplate = 'clean';
+    static $frontendlogin = false;
+    static $environment = "dev";    // dev/staging/live
+    static $channel = "stable";     // stable/alpha
+    static $updatedomain = "alba.holtbosse.com";
+    static $dev_banner = false;
 
-public static function __callStatic($name, $args) {
-    return property_exists('Config',$name) ? Config::$$name : null;
-}
+    public static function __callStatic($name, $args) {
+        return property_exists('Config',$name) ? Config::$$name : null;
+    }
+
 }

--- a/installer/index.php
+++ b/installer/index.php
@@ -36,12 +36,13 @@ function pprint_r ($msg) {
 
 function change_config_file_settings ($filePath, $newSettings) {
     // Build the new file as a string
-    $newFileStr = "<?php\n\ndefined('CMSPATH') or die; // prevent unauthorized access \n\n class Config {\n\n";
+    $newFileStr = "<?php\ndefined('CMSPATH') or die; // prevent unauthorized access \n\nclass Config {\n\n";
     foreach ($newSettings as $name => $val) {
         // Using var_export() allows you to set complex values such as arrays and also
         // ensures types will be correct
-        $newFileStr .= "static \${$name} = " . var_export($val, true) . ";\n";
+        $newFileStr .= "\tstatic \${$name} = " . var_export($val, true) . ";\n";
 	}
+	$newFileStr .= "\n\tpublic static function __callStatic(\$name, \$args) {\n\t\treturn property_exists('Config',\$name) ? Config::\$\$name : null;\n\t}";
 	$newFileStr .= "\n\n}"; // close class structure
     // Write it back to the file
     file_put_contents($filePath, $newFileStr);


### PR DESCRIPTION
Fixes #267. Basically static code required in config by CMS will now be added when the config is re-created by /installer/index.php. Also cleans up formatting.