### PR TITLE
bug: make repeatable indexed fields work properly with proper regex

### DIFF
--- a/core/fields/Field_Repeatable.php
+++ b/core/fields/Field_Repeatable.php
@@ -106,7 +106,7 @@ class Field_Repeatable extends Field {
 			var markup = window['repeatable_form_template_<?php echo $this->form->id;?>'].markup;
 			var repeat_count = document.getElementById('repeated_forms_container_<?php echo $this->form->id;?>').querySelectorAll('div.repeatable').length;
 			// insert index if required
-			markup = markup.replace('{{replace_with_index}}', repeat_count.toString());
+			markup = markup.replace(/{{replace_with_index}}/g, repeat_count.toString());
 			// insert unique id if required (image / slimselect js need unique ids for script)
 			var unique_id_suffix = '_' + Math.random().toString(36).substr(2, 9);
 			markup = markup.replace(/{{repeatable_id_suffix}}/g, unique_id_suffix);


### PR DESCRIPTION
see title. since the old line wasnt proper regex, it wasnt actually replacing anything. however when the page was reloaded, the php based indexing was kicking in, making it work on the second save

TLDR: repeatable's are driving me insane