### PR TITLE
feat: add option for select field to use ajax

### DIFF
--- a/core/fields/Field_Select.php
+++ b/core/fields/Field_Select.php
@@ -90,7 +90,33 @@ class Field_Select extends Field {
 			<script>
 				try {
 					document.getElementById('<?php echo $this->id;?>').slimselect = new SlimSelect({
-						select: '#<?php echo $this->id;?>'
+						select: '#<?php echo $this->id;?>',
+						<?php if($this->slimselect_ajax): ?>
+						searchingText: 'Searching...',
+						ajax: function (search, callback) {
+							if (search.length < <?php echo $this->slimselect_ajax_minchar; ?>) {
+								callback('Please enter at least <?php echo $this->slimselect_ajax_minchar; ?> characters')
+								return
+							}
+
+							fetch('<?php echo Config::uripath() . $this->slimselect_ajax_url; ?>?searchterm=' + encodeURI(search))
+							.then(function (response) {
+								return response.json()
+							})
+							.then(function (json) {
+								let data = [];
+								json.data.forEach((item)=>{
+									data.push({text: item.text, value: item.value})
+								});
+
+								//console.log(data);
+								callback(data);
+							})
+							.catch(function(error) {
+								callback(false)
+							})
+						}
+						<?php endif; ?>
 					});
 				} catch {
 					alert("SlimSelect is not present!");
@@ -150,6 +176,9 @@ class Field_Select extends Field {
 		$this->placeholder = $config->placeholder ?? '';
 		$this->slimselect = $config->slimselect ?: false;
 		$this->multiple = $config->multiple ?: false;
+		$this->slimselect_ajax = $config->slimselect_ajax ?? false;
+		$this->slimselect_ajax_url = $config->slimselect_ajax_url ?? "";
+		$this->slimselect_ajax_minchar = $config->slimselect_ajax_minchar ?? 3;
 		if ($this->multiple) {
 			$this->filter = $config->filter ?? 'ARRAYOFSTRING';
 		}


### PR DESCRIPTION
what it says on the tin
test code(core controller):

```php
<?php 

if(CMS::Instance()->uri_segments[1] && CMS::Instance()->uri_segments[1]=="api") {
    header('Content-Type: application/json; charset=utf-8');
    echo json_encode(["data"=>[
        (object)["text"=>$_GET["searchterm"] . "_" . uniqid(), "value"=>uniqid()],
        (object)["text"=>$_GET["searchterm"] . "_" . uniqid(), "value"=>uniqid()]
    ]]);
    die;
}

echo '<script src="https://cdnjs.cloudflare.com/ajax/libs/slim-select/1.27.1/slimselect.min.js"></script>';
echo '<link href="https://cdnjs.cloudflare.com/ajax/libs/slim-select/1.27.1/slimselect.min.css" rel="stylesheet">';

$form = new Form((object) [
    "id"=> "select_testing",
    "fields"=>[
        (object) [
            "name" => "models",
            "id" => "models",
            "type" => "Select",
            "label" => "Select Stuff",
            "slimselect" => true,
            "multiple" => true,
            "required" => false,
            "slimselect_ajax" => true,
            "slimselect_ajax_url" => "/selecttesting/api",
            "filter" => "RAW"
        ]
    ]
]);
$form->display_front_end();
```