### PR TITLE
Bettercontentsave

### DIFF
--- a/admin/controllers/categories/views/edit/model.php
+++ b/admin/controllers/categories/views/edit/model.php
@@ -60,7 +60,13 @@ if ($required_details_form->is_submitted()) {
 	if ($required_details_form->validate()) {
 		if (!$custom_fields_form || ($custom_fields_form && $custom_fields_form->validate()) ) {
 			// forms are valid, save info
-			$cat->save($required_details_form, $custom_fields_form);
+			$saved = $cat->save($required_details_form, $custom_fields_form);
+			if ($saved) {
+				CMS::Instance()->queue_message('Category saved','danger',$_SERVER['REQUEST_URI']);
+			}
+			else {
+				CMS::Instance()->queue_message('Failed to save category','danger',$_SERVER['REQUEST_URI']);
+			}
 		}
 		else {
 			CMS::Instance()->queue_message('Invalid form','danger',$_SERVER['REQUEST_URI']);	

--- a/admin/controllers/content/views/edit/model.php
+++ b/admin/controllers/content/views/edit/model.php
@@ -88,11 +88,13 @@ if ($required_details_form->is_submitted()) {
 		if ($saved) {
 			if ($quicksave) {
 				$redirect_to = $_SERVER['HTTP_REFERER'];
+				$msg = "Quicksave successful";
 			}
 			else {
 				$redirect_to = Config::uripath() . "/admin/content/all/" . $content->content_type;
+				$msg = "Content saved";
 			}
-			CMS::Instance()->queue_message('Quicksave successful','success', $redirect_to);
+			CMS::Instance()->queue_message($msg, 'success', $redirect_to);
 		}
 		else {
 			CMS::Instance()->queue_message('Invalid form','danger',$_SERVER['HTTP_REFERER']);

--- a/admin/controllers/content/views/edit/model.php
+++ b/admin/controllers/content/views/edit/model.php
@@ -83,12 +83,21 @@ if ($required_details_form->is_submitted()) {
 		} */
 
 		$quicksave = Input::getvar('quicksave',"STRING");
-		if ($quicksave) {
-			$content->save($required_details_form, $content_form, $_SERVER['HTTP_REFERER'] );
+		$saved = $content->save($required_details_form, $content_form );
+	
+		if ($saved) {
+			if ($quicksave) {
+				$redirect_to = $_SERVER['HTTP_REFERER'];
+			}
+			else {
+				$redirect_to = Config::uripath() . "/admin/content/all/" . $content->content_type;
+			}
+			CMS::Instance()->queue_message('Quicksave successful','success', $redirect_to);
 		}
 		else {
-			$content->save($required_details_form, $content_form);
+			CMS::Instance()->queue_message('Invalid form','danger',$_SERVER['HTTP_REFERER']);
 		}
+		
 	}
 	else {
 		CMS::Instance()->queue_message('Invalid form','danger',$_SERVER['REQUEST_URI']);	

--- a/admin/controllers/images/views/edit/model.php
+++ b/admin/controllers/images/views/edit/model.php
@@ -32,7 +32,13 @@ if ($required_details_form->is_submitted()) {
 	// validate
 	if ($required_details_form->validate()) {
 		// forms are valid, save info
-		$tag->save($required_details_form);
+		$saved = $tag->save($required_details_form);
+		if ($saved) {
+			CMS::Instance()->queue_message('Tag saved','danger', Config::uripath() . '/admin/content/all/' . $this->content_type;);
+		}
+		else {
+			CMS::Instance()->queue_message('Failed to save tag','danger',$_SERVER['REQUEST_URI']);
+		}
 	}
 	else {
 		CMS::Instance()->queue_message('Invalid form','danger',$_SERVER['REQUEST_URI']);	

--- a/admin/controllers/images/views/edit/model.php
+++ b/admin/controllers/images/views/edit/model.php
@@ -34,7 +34,7 @@ if ($required_details_form->is_submitted()) {
 		// forms are valid, save info
 		$saved = $tag->save($required_details_form);
 		if ($saved) {
-			CMS::Instance()->queue_message('Tag saved','danger', Config::uripath() . '/admin/content/all/' . $this->content_type;);
+			CMS::Instance()->queue_message('Tag saved','danger', Config::uripath() . '/admin/content/all/' . $this->content_type);
 		}
 		else {
 			CMS::Instance()->queue_message('Failed to save tag','danger',$_SERVER['REQUEST_URI']);

--- a/admin/controllers/images/views/edit/model.php
+++ b/admin/controllers/images/views/edit/model.php
@@ -34,7 +34,7 @@ if ($required_details_form->is_submitted()) {
 		// forms are valid, save info
 		$saved = $tag->save($required_details_form);
 		if ($saved) {
-			CMS::Instance()->queue_message('Tag saved','danger', Config::uripath() . '/admin/content/all/' . $this->content_type);
+			CMS::Instance()->queue_message('Tag saved','success', Config::uripath() . '/admin/content/all/' . $this->content_type);
 		}
 		else {
 			CMS::Instance()->queue_message('Failed to save tag','danger',$_SERVER['REQUEST_URI']);

--- a/admin/controllers/tags/views/edit/model.php
+++ b/admin/controllers/tags/views/edit/model.php
@@ -38,7 +38,13 @@ if ($required_details_form->is_submitted()) {
 	if ($required_details_form->validate()) {
 		if (!$custom_fields_form || ($custom_fields_form && $custom_fields_form->validate()) ) {
 			// forms are valid, save info
-			$tag->save($required_details_form, $custom_fields_form);
+			$saved = $tag->save($required_details_form, $custom_fields_form);
+			if ($saved) {
+				CMS::Instance()->queue_message('Tag saved','danger', "/admin/tags");
+			}
+			else {
+				CMS::Instance()->queue_message('Failed to save tag','danger',$_SERVER['REQUEST_URI']);
+			}
 		}
 		else {
 			CMS::Instance()->queue_message('Invalid field form','danger',$_SERVER['REQUEST_URI']);	

--- a/admin/controllers/tags/views/edit/model.php
+++ b/admin/controllers/tags/views/edit/model.php
@@ -40,7 +40,7 @@ if ($required_details_form->is_submitted()) {
 			// forms are valid, save info
 			$saved = $tag->save($required_details_form, $custom_fields_form);
 			if ($saved) {
-				CMS::Instance()->queue_message('Tag saved','danger', "/admin/tags");
+				CMS::Instance()->queue_message('Tag saved','success', "/admin/tags");
 			}
 			else {
 				CMS::Instance()->queue_message('Failed to save tag','danger',$_SERVER['REQUEST_URI']);

--- a/core/category.php
+++ b/core/category.php
@@ -91,10 +91,7 @@ class Category {
 		}
 	}
 
-	public function save($required_details_form, $custom_fields_form = "", $return_url='') {
-		// return url will be used as passed, if left blank will use referral
-		// unless in ADMIN section, in which case admin content all page will be used
-		
+	public function save($required_details_form, $custom_fields_form = "") {
 		// update this object with submitted and validated form info
 		$this->title = $required_details_form->get_field_by_name('title')->default;
 		$this->state = $required_details_form->get_field_by_name('state')->default;
@@ -115,25 +112,12 @@ class Category {
 			}
 		}
 		if (!$required_result) {
-			CMS::Instance()->queue_message('Failed to save category','danger', $_SERVER['HTTP_REFERER']);
+			CMS::Instance()->log("Failed to save category");
+			return false;
 		}
 
-		if (!$return_url) {
-			if (ADMINPATH) {
-				$return_url = Config::uripath() . '/admin/categories/all/' . $this->content_type;
-			}
-			else {
-				$return_url = $_SERVER['HTTP_REFERER'];
-			}
-		}
-
-		if ($error_text) {
-			CMS::Instance()->queue_message($error_text,'danger', $return_url);
-		}
-		else {
-			Hook::execute_hook_actions('on_category_save', $this);
-			CMS::Instance()->queue_message('Saved category','success', $return_url);
-		}
+		Hook::execute_hook_actions('on_category_save', $this);
+		return true;
 	}
 
 

--- a/core/tag.php
+++ b/core/tag.php
@@ -142,7 +142,8 @@ class Tag {
 					if ($parent_tag->parent) {
 						if ($parent_id==$this->parent) {
 							// can't be child of itself
-							CMS::Instance()->queue_message('Tag cannot be child of itself','danger',Config::uripath() . "/admin/tags");
+							CMS::Instance()->log('Tag cannot be child of itself');
+							return false;
 						}
 					}
 				}
@@ -169,10 +170,11 @@ class Tag {
 					DB::exec('insert into tag_content_type (tag_id,content_type_id) values (?,?)', array($this->id, $contenttype));
 				}
 				Hook::execute_hook_actions('on_tag_save', $this);
-				CMS::Instance()->queue_message('Tag updated','success',Config::$uripath . '/admin/tags/show');	
+				return true;	
 			}
 			else {
-				CMS::Instance()->queue_message('Tag failed to save','danger', $_SERVER['REQUEST_URI']);	
+				CMS::Instance()->log('Tag failed to save');
+				return false;
 			}
 		}
 		else {
@@ -195,10 +197,11 @@ class Tag {
 				}
 				$this->id = $new_id;
 				Hook::execute_hook_actions('on_tag_save', $this);
-				CMS::Instance()->queue_message('New tag saved','success',Config::$uripath . '/admin/tags/');	
+				return true;	
 			}
 			else {
-				CMS::Instance()->queue_message('New tag failed to save','danger', $_SERVER['REQUEST_URI']);	
+				CMS::Instance()->log('New tag failed to save');
+				return false;
 			}
 		}
 	}


### PR DESCRIPTION
Rectifying a silly historic decision to have various save functions be responsible for redirection/messaging instead of simply returning a boolean (and logging where necessary) and doing stuff after being called where appropriate.

This allows these functions to work better when called from front-end / non-core code.