### PR TITLE
feat: better no options form for view message

### DIFF
--- a/admin/controllers/pages/views/edit/view.php
+++ b/admin/controllers/pages/views/edit/view.php
@@ -278,10 +278,16 @@ div.position_tag_wrap.active {
 						// OLD method
 						//include_once (CMSPATH . "/controllers/" . $content_loc . "/views/" . $view_loc . "/options.php");
 						// NEW uses json forms
-						$options_form = new Form(CMSPATH . "/controllers/" . $content_loc . "/views/" . $view_loc . "/options_form.json");
-						// set options form values from json stored in view_configuration
-						$options_form->deserialize_json($page->view_configuration);
-						$options_form->display_front_end();
+						$options_form_filepath = CMSPATH . "/controllers/" . $content_loc . "/views/" . $view_loc . "/options_form.json";
+						if (is_file($options_form_filepath)) {
+							$options_form = new Form($options_form_filepath);
+							// set options form values from json stored in view_configuration
+							$options_form->deserialize_json($page->view_configuration);
+							$options_form->display_front_end();
+						}
+						else {
+							echo "<p>No options for this view.</p>";
+						}
 					}
 					else {
 						echo "<p>Choose a view first to see display options.</p>";


### PR DESCRIPTION
Hide error message if options form is not found in page editor in admin.

Looks like this: 

![image](https://github.com/HoltBosse/Alba/assets/23583515/e66d8e56-190f-4fae-978a-085f5d539baa)
