### PR TITLE
fix: Contentselector maybe others with empty_string

### DIFF
--- a/core/fields/Field_Select.php
+++ b/core/fields/Field_Select.php
@@ -50,6 +50,10 @@ class Field_Select extends Field {
 							$placeholder = $this->placeholder ?? $this->label;
 							echo "<option value='' >{$placeholder}</option>";
 						}
+						elseif ($this->empty_string) {
+							// not required, but we need a 0 value top option to signify nothing
+							echo "<option value='0' >{$this->empty_string}</option>";
+						}
 						foreach ($this->select_options as $select_option) {
 							$selected = "";
 							if ($this->multiple && $this->default != "" && in_array($select_option->value, json_decode($this->default))) {


### PR DESCRIPTION
empty_string is variable used in at least one 'select' child class (contentselector) to display an option with a 0 value at the top of a dropdown