### PR TITLE
phpstan level 1

### DIFF
--- a/core/cms.php
+++ b/core/cms.php
@@ -107,7 +107,7 @@ final class CMS {
 		// adds an action/filter to a hook - if hook doesn't exist, it's registered in CMS
 		if (!isset($GLOBALS['hooks'][$hook_label])) {
 			// hook not already registered, make new hook
-			$GLOBALS['hooks'][$hook_label] = new Hook ($hook_label);
+			$GLOBALS['hooks'][$hook_label] = new Hook ();
 		}
 		// add action to hook
 		$action = new stdClass();

--- a/core/cms.php
+++ b/core/cms.php
@@ -120,9 +120,9 @@ final class CMS {
 
 	public static function get_admin_template() {
 		$template="clean";
-		if (null !== config::admintemplate() && config::admintemplate()) {
-			if (file_exists(CURPATH . '/templates/' . config::admintemplate() . "/index.php")) {
-				$template = config::admintemplate();
+		if (null !== Config::admintemplate() && Config::admintemplate()) {
+			if (file_exists(CURPATH . '/templates/' . Config::admintemplate() . "/index.php")) {
+				$template = Config::admintemplate();
 			}
 		}
 		return $template;

--- a/core/fields/Field_Rich.php
+++ b/core/fields/Field_Rich.php
@@ -7,6 +7,7 @@ class Field_Rich extends Field {
 	public $tags;
 
 	function __construct($id="") {
+		$this->id = $id;
 		$this->mimetypes = [];
 		$this->tags = [];
 	}

--- a/core/fields/Field_Tab.php
+++ b/core/fields/Field_Tab.php
@@ -9,8 +9,8 @@ class Field_Tab extends Field {
 	public $input_type;
 	public $nowrap;
 
-	function __construct($default_content="") {
-		$this->id = "";
+	function __construct($id="") {
+		$this->id = $id;
 		$this->name = "";
 		$this->tabs = [];
 		$this->default = [];

--- a/core/hook.php
+++ b/core/hook.php
@@ -7,7 +7,7 @@ class Hook {
     public $actions;
     public $arg_count;
 
-	public function __construct($label) {
+	public function __construct() {
 		$this->label = false;
 		$this->actions = [];
 	}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -19,3 +19,4 @@ parameters:
 		- core/controllers # note this ignores the /image directory....
 	ignoreErrors:
 		- '#Call to an undefined static method Config::[a-zA-Z0-9\\_]()#'
+		- '#Variable \$[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]* might not be defined#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-	level: 0
+	level: 1
 	paths:
 		- core
 		- admin
@@ -14,5 +14,8 @@ parameters:
 		- widgets/menu
 		- widgets/crowdriff
 		- config.php
+		- index.php
 	excludePaths:
 		- core/controllers # note this ignores the /image directory....
+	ignoreErrors:
+		- '#Call to an undefined static method Config::[a-zA-Z0-9\\_]()#'


### PR DESCRIPTION
the first ignore rule is due to our use of __callstatic in the config file, probably fixable in the long term with some phpdoc comments or something
the second is due to variables not being defined in the current file