### PR TITLE
Better save

### DIFF
--- a/admin/controllers/categories/views/action/model.php
+++ b/admin/controllers/categories/views/action/model.php
@@ -18,7 +18,9 @@ if ($action=='toggle') {
 
 	$result = DB::exec("UPDATE categories SET state = (CASE state WHEN 1 THEN 0 ELSE 1 END) where id=?", array($id[0])); // id always array even with single id being passed
 	if ($result) {
-		CMS::Instance()->queue_message('Toggled state of Category','success', $_SERVER['HTTP_REFERER']);
+		$title = DB::fetch('SELECT title FROM categories WHERE id=?', [$id[1]])->title;
+		$msg = "Category <a href='" . Config::uripath() . "/admin/categories/edit/{$id[0]}'>{$title}</a> state toggled";	
+		CMS::Instance()->queue_message($msg,'success', $_SERVER['HTTP_REFERER']);
 	}
 	else {
 		CMS::Instance()->queue_message('Failed to toggle state of Category','danger', $_SERVER['HTTP_REFERER']);

--- a/admin/controllers/categories/views/edit/model.php
+++ b/admin/controllers/categories/views/edit/model.php
@@ -62,7 +62,8 @@ if ($required_details_form->is_submitted()) {
 			// forms are valid, save info
 			$saved = $cat->save($required_details_form, $custom_fields_form);
 			if ($saved) {
-				CMS::Instance()->queue_message('Category saved','success',Config::uripath() . "/admin/categories");
+				$msg = 'Category <a href="' . Config::uripath() . '/admin/categories/edit/' . $cat->id . '">' . $cat->title . '</a> ' . ($new_cat ? 'created' : 'updated');
+				CMS::Instance()->queue_message($msg, 'success', Config::uripath() . '/admin/categories');
 			}
 			else {
 				CMS::Instance()->queue_message('Failed to save category','danger',$_SERVER['REQUEST_URI']);

--- a/admin/controllers/categories/views/edit/model.php
+++ b/admin/controllers/categories/views/edit/model.php
@@ -62,7 +62,7 @@ if ($required_details_form->is_submitted()) {
 			// forms are valid, save info
 			$saved = $cat->save($required_details_form, $custom_fields_form);
 			if ($saved) {
-				$msg = 'Category <a href="' . Config::uripath() . '/admin/categories/edit/' . $cat->id . '">' . $cat->title . '</a> ' . ($new_cat ? 'created' : 'updated');
+				$msg = "Category <a href='" . Config::uripath() . "/admin/categories/edit/{$cat->id}'>{$cat->title}</a> " . ($new_cat ? 'created' : 'updated');	
 				CMS::Instance()->queue_message($msg, 'success', Config::uripath() . '/admin/categories');
 			}
 			else {

--- a/admin/controllers/content/views/action/model.php
+++ b/admin/controllers/content/views/action/model.php
@@ -35,7 +35,9 @@ if ($action=='toggle') {
 
 	$result = DB::exec("update `$table_name` SET state = (CASE state WHEN 1 THEN 0 ELSE 1 END) where id=?", [$id[0]]); // id always array even with single id being passed
 	if ($result) {
-		CMS::Instance()->queue_message('Toggled state of content','success', $_SERVER['HTTP_REFERER']);
+		$content = DB::fetch("SELECT * FROM `$table_name` WHERE id=?", [$id[0]]);
+		$msg = "Content <a href='" . Config::uripath() . "/admin/content/edit/{$id[0]}/{$content->content_type}'>{$content->title}</a> state toggled";
+		CMS::Instance()->queue_message($msg,'success', $_SERVER['HTTP_REFERER']);
 	}
 	else {
 		CMS::Instance()->queue_message('Failed to toggle state of content','danger', $_SERVER['HTTP_REFERER']);

--- a/admin/controllers/content/views/all/view.php
+++ b/admin/controllers/content/views/all/view.php
@@ -128,7 +128,7 @@ table.dragging .before_after_wrap {
 
 .state_button button {
 	height: 100%;
-	padding: 0 0.75em;
+	padding: 1em 1em;
 	border: 1px solid transparent;
 	width: 100%;
 	background-color: #fff;

--- a/admin/controllers/content/views/edit/model.php
+++ b/admin/controllers/content/views/edit/model.php
@@ -24,7 +24,7 @@ elseif(sizeof($segments)==4 && $segments[2]=='new' && is_numeric($segments[3])) 
 	$new_content = true;
 }
 else {
-	CMS::Instance()->queue_message('Unknown content operation','danger',Config::uripath().'/admin/content/show');
+	CMS::Instance()->queue_message('Unknown content operation','danger',Config::uripath().'/admin');
 	exit(0);
 }
 
@@ -95,7 +95,7 @@ if ($required_details_form->is_submitted()) {
 			}
 			else {
 				$redirect_to = Config::uripath() . "/admin/content/all/" . $content->content_type;
-				$msg = 'Content <a href="' . Config::uripath() . '/admin/content/edit/'.  $content->id . '/'. $content_type . '">' . $content->title .'</a> saved';
+				$msg = 'Content <a href="' . Config::uripath() . '/admin/content/edit/'.  $contentt->id . '/'. $content_type . '">' . $content->title .'</a> saved';
 			}
 			CMS::Instance()->queue_message($msg, 'success', $redirect_to);
 		}

--- a/admin/controllers/content/views/edit/model.php
+++ b/admin/controllers/content/views/edit/model.php
@@ -95,7 +95,7 @@ if ($required_details_form->is_submitted()) {
 			}
 			else {
 				$redirect_to = Config::uripath() . "/admin/content/all/" . $content->content_type;
-				$msg = 'Content <a href="' . Config::uripath() . '/admin/content/edit/' . $content->id . '/' . $content_type . '">' . $content->title . '</a> ' . ($new_content ? 'created' : 'updated');
+				$msg = "Content <a href='" . Config::uripath() . "/admin/content/edit/{$content->id}/{$content_type}'>{$content->title}</a> " . ($new_content ? 'created' : 'updated');
 			}
 			CMS::Instance()->queue_message($msg, 'success', $redirect_to);
 		}

--- a/admin/controllers/content/views/edit/model.php
+++ b/admin/controllers/content/views/edit/model.php
@@ -95,7 +95,7 @@ if ($required_details_form->is_submitted()) {
 			}
 			else {
 				$redirect_to = Config::uripath() . "/admin/content/all/" . $content->content_type;
-				$msg = "Content saved";
+				$msg = 'Content <a href="' . Config::uripath() . '/admin/content/edit/'.  $content->id . '/'. $content_type . '">' . $content->title .'</a> saved';
 			}
 			CMS::Instance()->queue_message($msg, 'success', $redirect_to);
 		}

--- a/admin/controllers/content/views/edit/model.php
+++ b/admin/controllers/content/views/edit/model.php
@@ -95,7 +95,7 @@ if ($required_details_form->is_submitted()) {
 			}
 			else {
 				$redirect_to = Config::uripath() . "/admin/content/all/" . $content->content_type;
-				$msg = 'Content <a href="' . Config::uripath() . '/admin/content/edit/'.  $contentt->id . '/'. $content_type . '">' . $content->title .'</a> saved';
+				$msg = 'Content <a href="' . Config::uripath() . '/admin/content/edit/' . $content->id . '/' . $content_type . '">' . $content->title . '</a> ' . ($new_content ? 'created' : 'updated');
 			}
 			CMS::Instance()->queue_message($msg, 'success', $redirect_to);
 		}

--- a/admin/controllers/pages/views/action/model.php
+++ b/admin/controllers/pages/views/action/model.php
@@ -18,7 +18,9 @@ if ($action=='toggle') {
 	]);
 	$result = DB::exec("UPDATE pages SET state = (CASE state WHEN 1 THEN 0 ELSE 1 END) where id=?", [$id[0]]); // id always array even with single id being passed
 	if ($result) {
-		CMS::Instance()->queue_message('Toggled state of page','success', $_SERVER['HTTP_REFERER']);
+		$page = DB::fetch('SELECT * FROM pages WHERE id=?', [$id[0]]);
+		$msg = "Page <a href='" . Config::uripath() . "/admin/pages/edit/{$id[0]}/{$page->content_type}/{$page->view}'>{$page->title}</a> state toggled";
+		CMS::Instance()->queue_message($msg,'success', $_SERVER['HTTP_REFERER']);
 	}
 	else {
 		CMS::Instance()->queue_message('Failed to toggle state of page','danger', $_SERVER['HTTP_REFERER']);

--- a/admin/controllers/pages/views/save/model.php
+++ b/admin/controllers/pages/views/save/model.php
@@ -58,7 +58,7 @@ if ($success) {
 		$override_success = DB::exec("insert into page_widget_overrides (page_id, position, widgets) values (?,?,?) on duplicate key update page_id=?, position=?, widgets=?", $data);
 	}
 
-	$msg = 'Page <a href="' . Config::uripath() . '/admin/pages/edit/' . $page->id . '/' . $page->content_type . '/' . $page->view . '">' . $page->title . '</a> ' . $status . ($new_page ? 'created' : 'updated');
+	$msg = "Page <a href='" . Config::uripath() . "/admin/pages/edit/{$page->id}/{$page->content_type}/{$page->view}'>{$page->title}</a> $status" . ($new_page ? 'created' : 'updated');
 	CMS::Instance()->queue_message($msg, 'success', Config::uripath().'/admin/pages');
 }
 else {

--- a/admin/controllers/pages/views/save/model.php
+++ b/admin/controllers/pages/views/save/model.php
@@ -12,6 +12,7 @@ if (!$success) {
 }
 
 if(Input::getvar("id")==0) {
+	$new_page = true;
 	$existing_page = DB::fetch("SELECT * FROM pages WHERE alias=? AND parent=?", [$page->alias, $page->parent]);
 	if($existing_page) {
 		CMS::Instance()->queue_message('Page already exists (user created)','danger',Config::uripath().'/admin/pages');
@@ -56,10 +57,9 @@ if ($success) {
 		$data = array( $page->id, $_POST['override_positions'][$n], $_POST['override_positions_widgets'][$n], $page->id, $_POST['override_positions'][$n], $_POST['override_positions_widgets'][$n] );
 		$override_success = DB::exec("insert into page_widget_overrides (page_id, position, widgets) values (?,?,?) on duplicate key update page_id=?, position=?, widgets=?", $data);
 	}
-	
-	
 
-	CMS::Instance()->queue_message('Page created/updated','success',Config::uripath().'/admin/pages');
+	$msg = 'Page <a href="' . Config::uripath() . '/admin/pages/edit/' . $page->id . '/' . $page->content_type . '/' . $page->view . '">' . $page->title . '</a> ' . $status . ($new_page ? 'created' : 'updated');
+	CMS::Instance()->queue_message($msg, 'success', Config::uripath().'/admin/pages');
 }
 else {
 	CMS::Instance()->queue_message('Page creation/update failed','danger',Config::uripath().'/admin/pages');

--- a/admin/controllers/plugins/views/action/model.php
+++ b/admin/controllers/plugins/views/action/model.php
@@ -14,7 +14,9 @@ if (!$id) {
 if ($action=='toggle') {
 	$result = DB::exec("UPDATE plugins SET state = (CASE state WHEN 1 THEN 0 ELSE 1 END) where id=?", [$id[0]]); // id always array even with single id being passed
 	if ($result) {
-		CMS::Instance()->queue_message('Toggled state of plugin','success', $_SERVER['HTTP_REFERER']);
+		$plugin = DB::fetch('SELECT * FROM plugins WHERE id=?', [$id[0]]);
+		$msg = "Plugin <a href='" . Config::uripath() . "/admin/plugins/edit/{$id[0]}'>{$plugin->title}</a> state toggled";
+		CMS::Instance()->queue_message($msg,'success', $_SERVER['HTTP_REFERER']);
 	}
 	else {
 		CMS::Instance()->queue_message('Failed to toggle state of plugin','danger', $_SERVER['HTTP_REFERER']);

--- a/admin/controllers/redirects/views/action/model.php
+++ b/admin/controllers/redirects/views/action/model.php
@@ -14,7 +14,9 @@ if ($action=='toggle') {
 	}
 	$result = DB::exec("update `$table_name` SET state = (CASE state WHEN 1 THEN 0 ELSE 1 END) where id=?", [$id[0]]); // id always array even with single id being passed
 	if ($result) {
-		CMS::Instance()->queue_message('Toggled state of redirect','success', $_SERVER['HTTP_REFERER']);
+		$redirect = DB::fetch('SELECT * FROM redirects WHERE id=?', [$id[0]]);
+		$msg = "Redirect <a href='" . Config::uripath() . "/admin/redirects/edit/{$id[0]}'>item</a> state toggled";
+		CMS::Instance()->queue_message($msg,'success', $_SERVER['HTTP_REFERER']);
 	}
 	else {
 		CMS::Instance()->queue_message('Failed to toggle state of redirect','danger', $_SERVER['HTTP_REFERER']);

--- a/admin/controllers/redirects/views/all/view.php
+++ b/admin/controllers/redirects/views/all/view.php
@@ -128,7 +128,7 @@ table.dragging .before_after_wrap {
 
 .state_button button {
 	height: 100%;
-	padding: 0 0.75em;
+	padding: 1em 1em;
 	border: 1px solid transparent;
 	width: 100%;
 	background-color: #fff;

--- a/admin/controllers/tags/views/action/model.php
+++ b/admin/controllers/tags/views/action/model.php
@@ -18,7 +18,9 @@ if ($action=='toggle') {
 	
 	$result = DB::exec("UPDATE tags SET state = (CASE state WHEN 1 THEN 0 ELSE 1 END) where id=?", array($id[0])); // id always array even with single id being passed
 	if ($result) {
-		CMS::Instance()->queue_message('Toggled state of tag','success', $_SERVER['HTTP_REFERER']);
+		$tag = DB::fetch('SELECT * FROM tags WHERE id=?', [$id[0]]);
+		$msg = "Tag <a href='" . Config::uripath() . "/admin/tags/edit/{$id[0]}'>{$tag->title}</a> state toggled";
+		CMS::Instance()->queue_message($msg,'success', $_SERVER['HTTP_REFERER']);
 	}
 	else {
 		CMS::Instance()->queue_message('Failed to toggle state of tag','danger', $_SERVER['HTTP_REFERER']);

--- a/admin/controllers/tags/views/edit/model.php
+++ b/admin/controllers/tags/views/edit/model.php
@@ -39,8 +39,10 @@ if ($required_details_form->is_submitted()) {
 		if (!$custom_fields_form->id || ($custom_fields_form && $custom_fields_form->validate()) ) {
 			// forms are valid, save info
 			$saved = $tag->save($required_details_form, $custom_fields_form);
+			// CMS::pprint_r($tag); die;
 			if ($saved) {
-				CMS::Instance()->queue_message('Tag saved','success', "/admin/tags");
+				$msg = 'Tag <a href="' . Config::uripath() . '/admin/tags/edit/' . $tag->id . '">' . $tag->title . '</a> ' . ($new_tag ? 'created' : 'updated');
+				CMS::Instance()->queue_message($msg, 'success', Config::uripath() . '/admin/tags');
 			}
 			else {
 				CMS::Instance()->queue_message('Failed to save tag','danger',$_SERVER['REQUEST_URI']);

--- a/admin/controllers/tags/views/edit/model.php
+++ b/admin/controllers/tags/views/edit/model.php
@@ -41,7 +41,7 @@ if ($required_details_form->is_submitted()) {
 			$saved = $tag->save($required_details_form, $custom_fields_form);
 			// CMS::pprint_r($tag); die;
 			if ($saved) {
-				$msg = 'Tag <a href="' . Config::uripath() . '/admin/tags/edit/' . $tag->id . '">' . $tag->title . '</a> ' . ($new_tag ? 'created' : 'updated');
+				$msg = "Tag <a href='" . Config::uripath() . "/admin/tags/edit/{$tag->id}'>{$tag->title}</a> " . ($new_tag ? 'created' : 'updated');
 				CMS::Instance()->queue_message($msg, 'success', Config::uripath() . '/admin/tags');
 			}
 			else {

--- a/admin/controllers/users/views/action/model.php
+++ b/admin/controllers/users/views/action/model.php
@@ -20,7 +20,9 @@ if ($action=='toggle') {
 
 	$result = DB::exec("UPDATE users SET state = (CASE state WHEN 1 THEN 0 ELSE 1 END) where id=?", array($id[0])); // id always array even with single id being passed
 	if ($result) {
-		CMS::Instance()->queue_message('Toggled state of user','success', $_SERVER['HTTP_REFERER']);
+		$user = DB::fetch('SELECT * FROM users WHERE id=?', [$id[0]]);
+		$msg = "User <a href='" . Config::uripath() . "/admin/users/edit/{$id[0]}'>{$user->username}</a> state toggled";
+		CMS::Instance()->queue_message($msg,'success', $_SERVER['HTTP_REFERER']);
 	}
 	else {
 		CMS::Instance()->queue_message('Failed to toggle state of user','danger', $_SERVER['HTTP_REFERER']);

--- a/admin/controllers/users/views/save/model.php
+++ b/admin/controllers/users/views/save/model.php
@@ -63,7 +63,7 @@ if ($custom_user_fields_form) {
 if ($success) {
 	Hook::execute_hook_actions('on_user_save',$user);
 	if (!$custom_field_error) {
-		$msg = 'User <a href="' . Config::uripath() . '/admin/users/edit/' . $user->id . '">' . $user->username . '</a> ' . ($new_user ? 'created' : 'updated');
+		$msg = "User <a href='" . Config::uripath() . "/admin/users/edit/{$user->id}'>{$user->username}</a> " . ($new_user ? 'created' : 'updated');
 		CMS::Instance()->queue_message($msg, 'success', Config::uripath() . '/admin/users');
 	}
 	else {

--- a/admin/controllers/users/views/save/model.php
+++ b/admin/controllers/users/views/save/model.php
@@ -12,6 +12,7 @@ if (!$user_ok) {
 	CMS::Instance()->queue_message('Failed to create user object from form data','danger',Config::uripath().'/admin/users');
 }
 $response = Hook::execute_hook_actions('validate_user_fields_form');
+$new_user = !$user->id; //check for new user
 
 $success = $user->save();
 $custom_field_error = false; // only set to true if any errors occur during custom field saving
@@ -62,7 +63,8 @@ if ($custom_user_fields_form) {
 if ($success) {
 	Hook::execute_hook_actions('on_user_save',$user);
 	if (!$custom_field_error) {
-		CMS::Instance()->queue_message('User saved','success',Config::uripath().'/admin/users');
+		$msg = 'User <a href="' . Config::uripath() . '/admin/users/edit/' . $user->id . '">' . $user->username . '</a> ' . ($new_user ? 'created' : 'updated');
+		CMS::Instance()->queue_message($msg, 'success', Config::uripath() . '/admin/users');
 	}
 	else {
 		CMS::Instance()->queue_message('User saved, additional fields had 1 or more errors. See Log.','warning',Config::uripath().'/admin/users');

--- a/admin/controllers/widgets/views/action/model.php
+++ b/admin/controllers/widgets/views/action/model.php
@@ -14,7 +14,9 @@ if (!$id) {
 if ($action=='toggle') {
 	$result = DB::exec("UPDATE widgets SET state = (CASE state WHEN 1 THEN 0 ELSE 1 END) where id=?", array($id[0])); // id always array even with single id being passed
 	if ($result) {
-		CMS::Instance()->queue_message('Toggled state of widget','success', $_SERVER['HTTP_REFERER']);
+		$widget = DB::fetch('SELECT * FROM widgets WHERE id=?', [$id[0]]);
+		$msg = "Widget <a href='" . Config::uripath() . "/admin/widgets/edit/{$id[0]}'>{$widget->title}</a> state toggled";
+		CMS::Instance()->queue_message($msg,'success', $_SERVER['HTTP_REFERER']);
 	}
 	else {
 		CMS::Instance()->queue_message('Failed to toggle state of widget','danger', $_SERVER['HTTP_REFERER']);

--- a/admin/controllers/widgets/views/edit/view.php
+++ b/admin/controllers/widgets/views/edit/view.php
@@ -13,6 +13,7 @@ defined('CMSPATH') or die; // prevent unauthorized access
 <hr>
 
 <form method="POST" action="">
+<input type="hidden" name="http_referer_form" value="<?php echo $_SERVER['HTTP_REFERER'];?>">
 <a href='#' class='toggle_siblings'>show/hide required fields</a>
 <div class='toggle_wrap <?php if (!$new_widget) { echo " hidden ";}?>'>
 	<div class='flex'>

--- a/core/plugin.php
+++ b/core/plugin.php
@@ -85,7 +85,8 @@ class Plugin {
 			$result = DB::exec("update plugins set options=? where id=?", [$options_json, $this->id]);
 			
 			if ($result) {
-				CMS::Instance()->queue_message('Plugin options updated','success',Config::uripath() . '/admin/plugins/show');	
+				$msg = 'Plugin <a href="' . Config::uripath() . '/admin/plugins/edit/' . $this->id . '">' . $this->title . '</a> ' . 'updated';
+				CMS::Instance()->queue_message($msg, 'success', Config::uripath() . '/admin/plugins/show');
 			}
 			else {
 				CMS::Instance()->queue_message('Plugin failed to save','danger',Config::uripath() . $_SERVER['REQUEST_URI']);	

--- a/core/plugin.php
+++ b/core/plugin.php
@@ -85,7 +85,7 @@ class Plugin {
 			$result = DB::exec("update plugins set options=? where id=?", [$options_json, $this->id]);
 			
 			if ($result) {
-				$msg = 'Plugin <a href="' . Config::uripath() . '/admin/plugins/edit/' . $this->id . '">' . $this->title . '</a> ' . 'updated';
+				$msg = "Plugin <a href='" . Config::uripath() . "/admin/plugins/edit/{$this->id}'>{$this->title}</a> updated";	
 				CMS::Instance()->queue_message($msg, 'success', Config::uripath() . '/admin/plugins/show');
 			}
 			else {

--- a/core/widget.php
+++ b/core/widget.php
@@ -141,6 +141,10 @@ class Widget {
 
 	public function save($required_details_form, $widget_options_form, $position_options_form) {
 		// update this object with submitted and validated form info
+		$redirect_url = Config::uripath() . '/admin/widgets/show';
+		if (Input::getvar("http_referer_form") && Input::getvar("http_referer_form") != $_SERVER["HTTP_REFERER"]){
+			$redirect_url = Input::getvar("http_referer_form");
+		}
 		$this->title = $required_details_form->get_field_by_name('title')->default;
 		$this->state = $required_details_form->get_field_by_name('state')->default;
 		$this->note = $required_details_form->get_field_by_name('note')->default;
@@ -172,7 +176,7 @@ class Widget {
 			$result = DB::exec("update widgets set state=?, title=?, note=?, options=?, position_control=?, global_position=?, page_list=? where id=?", $params);
 			
 			if ($result) {
-				CMS::Instance()->queue_message('Widget updated','success',Config::uripath() . '/admin/widgets/show');	
+				CMS::Instance()->queue_message('Widget updated','success', $redirect_url);	
 			}
 			else {
 				CMS::Instance()->queue_message('Widget failed to save','danger',Config::uripath() . $_SERVER['REQUEST_URI']);	
@@ -183,7 +187,7 @@ class Widget {
 			$params = array($this->state, $this->type_id, $this->title, $this->note, $options_json, $this->position_control, $this->global_position, implode(',',$this->page_list)) ;
 			$result = DB::exec("insert into widgets (state,type,title,note,options,position_control,global_position,page_list) values(?,?,?,?,?,?,?,?)", $params);
 			if ($result) {
-				CMS::Instance()->queue_message('New widget saved','success',Config::uripath() . '/admin/widgets/show');	
+				CMS::Instance()->queue_message('New widget saved','success', $redirect_url);	
 			}
 			else {
 				CMS::Instance()->queue_message('New widget failed to save','danger',Config::uripath() . $_SERVER['REQUEST_URI']);	

--- a/core/widget.php
+++ b/core/widget.php
@@ -176,7 +176,7 @@ class Widget {
 			$result = DB::exec("update widgets set state=?, title=?, note=?, options=?, position_control=?, global_position=?, page_list=? where id=?", $params);
 			
 			if ($result) {
-				CMS::Instance()->queue_message('Widget <a href="' . Config::uripath() . '/admin/widgets/edit/'.  $this->id . '">' . $this->title .'</a> updated.','success', $redirect_url);	
+				CMS::Instance()->queue_message('Widget <a href="' . Config::uripath() . '/admin/widgets/edit/'.  $this->id . '">' . $this->title .'</a> updated','success', $redirect_url);	
 			}
 			else {
 				CMS::Instance()->queue_message('Widget failed to save','danger',Config::uripath() . $_SERVER['REQUEST_URI']);	
@@ -188,7 +188,7 @@ class Widget {
 			$result = DB::exec("insert into widgets (state,type,title,note,options,position_control,global_position,page_list) values(?,?,?,?,?,?,?,?)", $params);
 			$new_widget_id = DB::get_last_insert_id();
 			if ($result) {
-				CMS::Instance()->queue_message('New widget <a href="' . Config::uripath() . '/admin/widgets/edit/'.  $new_widget_id . '">' . $this->title .'</a> saved','success', $redirect_url);	
+				CMS::Instance()->queue_message('Widget <a href="' . Config::uripath() . '/admin/widgets/edit/'.  $new_widget_id . '">' . $this->title .'</a> created','success', $redirect_url);	
 			}
 			else {
 				CMS::Instance()->queue_message('New widget failed to save','danger',Config::uripath() . $_SERVER['REQUEST_URI']);	

--- a/core/widget.php
+++ b/core/widget.php
@@ -176,7 +176,7 @@ class Widget {
 			$result = DB::exec("update widgets set state=?, title=?, note=?, options=?, position_control=?, global_position=?, page_list=? where id=?", $params);
 			
 			if ($result) {
-				CMS::Instance()->queue_message('Widget updated','success', $redirect_url);	
+				CMS::Instance()->queue_message('Widget <a href="' . Config::uripath() . '/admin/widgets/edit/'.  $this->id . '">' . $this->title .'</a> updated.','success', $redirect_url);	
 			}
 			else {
 				CMS::Instance()->queue_message('Widget failed to save','danger',Config::uripath() . $_SERVER['REQUEST_URI']);	
@@ -186,8 +186,9 @@ class Widget {
 			// new
 			$params = array($this->state, $this->type_id, $this->title, $this->note, $options_json, $this->position_control, $this->global_position, implode(',',$this->page_list)) ;
 			$result = DB::exec("insert into widgets (state,type,title,note,options,position_control,global_position,page_list) values(?,?,?,?,?,?,?,?)", $params);
+			$new_widget_id = DB::get_last_insert_id();
 			if ($result) {
-				CMS::Instance()->queue_message('New widget saved','success', $redirect_url);	
+				CMS::Instance()->queue_message('New widget <a href="' . Config::uripath() . '/admin/widgets/edit/'.  $new_widget_id . '">' . $this->title .'</a> saved','success', $redirect_url);	
 			}
 			else {
 				CMS::Instance()->queue_message('New widget failed to save','danger',Config::uripath() . $_SERVER['REQUEST_URI']);	

--- a/core/widget.php
+++ b/core/widget.php
@@ -176,7 +176,7 @@ class Widget {
 			$result = DB::exec("update widgets set state=?, title=?, note=?, options=?, position_control=?, global_position=?, page_list=? where id=?", $params);
 			
 			if ($result) {
-				CMS::Instance()->queue_message('Widget <a href="' . Config::uripath() . '/admin/widgets/edit/'.  $this->id . '">' . $this->title .'</a> updated','success', $redirect_url);	
+				CMS::Instance()->queue_message("Widget <a href='" . Config::uripath() . "/admin/widgets/edit/{$this->id}'>{$this->title}</a> updated", 'success', $redirect_url);
 			}
 			else {
 				CMS::Instance()->queue_message('Widget failed to save','danger',Config::uripath() . $_SERVER['REQUEST_URI']);	
@@ -188,7 +188,7 @@ class Widget {
 			$result = DB::exec("insert into widgets (state,type,title,note,options,position_control,global_position,page_list) values(?,?,?,?,?,?,?,?)", $params);
 			$new_widget_id = DB::get_last_insert_id();
 			if ($result) {
-				CMS::Instance()->queue_message('Widget <a href="' . Config::uripath() . '/admin/widgets/edit/'.  $new_widget_id . '">' . $this->title .'</a> created','success', $redirect_url);	
+				CMS::Instance()->queue_message("Widget <a href='" . Config::uripath() . "/admin/widgets/edit/{$new_widget_id}'>{$this->title}</a> created", 'success', $redirect_url);	
 			}
 			else {
 				CMS::Instance()->queue_message('New widget failed to save','danger',Config::uripath() . $_SERVER['REQUEST_URI']);	

--- a/plugins/core_frontend_editbutton/plugin_class.php
+++ b/plugins/core_frontend_editbutton/plugin_class.php
@@ -47,7 +47,7 @@ class Plugin_core_frontend_editbutton extends Plugin {
             } else {
                 $page_contents = "
                     <div class='front_end_edit_wrap' >
-                        <a style='' target='_blank' href='/admin/widgets/edit/{$params[0]->id}'>EDIT &ldquo;" . htmlspecialchars($params[0]->title) . "&rdquo;</a>
+                        <a style='' href='/admin/widgets/edit/{$params[0]->id}'>EDIT &ldquo;" . htmlspecialchars($params[0]->title) . "&rdquo;</a>
                     </div>
                 " . $page_contents;
             }


### PR DESCRIPTION
- When saving content items, widgets, pages, users, tags, etc, it returns to the previous page. 
- Success messages now contain a link back to the edited item.