### PR TITLE
Userloginaudit

### DIFF
--- a/core/actions.php
+++ b/core/actions.php
@@ -30,7 +30,11 @@ class Actions {
 
     public function render_user() {
         $user = DB::fetch("SELECT * FROM users WHERE id=?", $this->userid);
-        return "$user->username ($user->email)";
+        if($user->id) {
+            return "$user->username ($user->email)";
+        } else {
+            return "unknown";
+        }
     }
 
     public function render_time() {

--- a/core/actions/Action_userlogin.php
+++ b/core/actions/Action_userlogin.php
@@ -1,0 +1,16 @@
+<?php
+defined('CMSPATH') or die; // prevent unauthorized access
+
+class Action_userlogin extends Actions {
+
+    public function display() {
+        $userDetails = DB::fetch("SELECT * FROM users WHERE id=?", $this->options->user);
+
+        $url = null;
+        if($userDetails->state>0) {
+            $url = "/admin/users/edit/" . $userDetails->id;
+        }
+
+        $this->render_row($url, "User $userDetails->username ($userDetails->email) logged in");
+    }
+}

--- a/core/cms.php
+++ b/core/cms.php
@@ -598,6 +598,9 @@ final class CMS {
 					$redirect_path = $_SESSION['redirect_url'];
 					unset($_SESSION['redirect_url']);
 				}
+				Actions::add_action("userlogin", (object) [
+					"user"=>$this->user->id,
+				], $this->user->id);
 				Hook::execute_hook_actions('user_logged_in'); 
 				$this->queue_message('Welcome ' . $this->user->username, 'success', $redirect_path);
 			}
@@ -621,6 +624,9 @@ final class CMS {
 							$redirect_path = $_SESSION['redirect_url'];
 							unset($_SESSION['redirect_url']);
 						}
+						Actions::add_action("userlogin", (object) [
+							"user"=>$login_user->id,
+						], $login_user->id);
 						Hook::execute_hook_actions('user_logged_in'); 
 						$this->queue_message('Welcome ' . $login_user->username, 'success', $redirect_path);
 					}


### PR DESCRIPTION
pr does two things

* fixes and issue where the audit log would show `()` if there was no user, which is bad for audit actions done by unlogged in users, such as on a front end (there is a hack that shows this same unknown value on a certain site)
* adds audit log tracking of users that log in