### PR TITLE
bug: make serialization honor save param, apply save field to page options

### DIFF
--- a/admin/controllers/pages/page_options.json
+++ b/admin/controllers/pages/page_options.json
@@ -3,7 +3,8 @@
 	"fields":[
 		{
 			"type":"HTML",
-			"html":"<h4 class='title is-4 is-heading'>Access</h4>"
+			"html":"<h4 class='title is-4 is-heading'>Access</h4>",
+			"save": false
 		},
 		{
 			"type":"UserGroupsMultiple",
@@ -15,7 +16,8 @@
 		},
 		{
 			"type":"HTML",
-			"html":"<h4 class='title is-4 is-heading'>SEO / Social</h4><p>If the page content is a collection or has no SEO/Opengraph entries of its own, then these values will be used. It's best to set them here just to be safe.</p><br>"
+			"html":"<h4 class='title is-4 is-heading'>SEO / Social</h4><p>If the page content is a collection or has no SEO/Opengraph entries of its own, then these values will be used. It's best to set them here just to be safe.</p><br>",
+			"save": false
 		},
 		{
 			"name":"og_description",

--- a/core/form.php
+++ b/core/form.php
@@ -163,7 +163,9 @@ class Form {
 			else {
 				$pair->value = $field->default;
 			}
-			$name_value_pairs[] = $pair;
+			if($field->save!==false) {
+				$name_value_pairs[] = $pair;
+			}
 		}
 		return json_encode ($name_value_pairs);
 	}
@@ -172,6 +174,12 @@ class Form {
 		$json_obj = json_decode($json);
 		if ($json_obj) {
 			foreach ($json_obj as $option) {
+				/*
+					this is a legacy check that exists due to:
+					1. the page form having fields without save
+					2. serialization logic not handling save field
+					3. serialization handling of fields without names
+				*/
 				if ($option->name!=='error!!!') {
 					$field = $this->get_field_by_name($option->name); 
 					if (is_object($field)) {


### PR DESCRIPTION
was digging around in pages, figuring out exactly how they worked, and found fields with "error!!!" in them, so fixed that