### PR TITLE
feat: add the same hooks as content search for user search

### DIFF
--- a/admin/controllers/users/views/default/view.php
+++ b/admin/controllers/users/views/default/view.php
@@ -118,6 +118,8 @@ defined('CMSPATH') or die; // prevent unauthorized access
 			select:'#user_search_groups'
 		});
 		</script>
+
+		<?php Hook::execute_hook_actions('render_custom_user_search_filters'); ?>
 		
 		<div class='field'>
 			<label class="label">&nbsp;</label>


### PR DESCRIPTION
does what it says on the tin.

only tested three of the five, but should all be good.

sample plugin that allows searching users by id:
```php
class Plugin_user_admin_search extends Plugin {
    public function init() {
        CMS::add_action("render_custom_user_search_filters",$this,'user_render_search_fields'); // label, function, priority
        CMS::add_action("custom_user_search_where",$this,'user_handle_search_where'); // label, function, priority
        CMS::add_action("custom_user_search_params",$this,'user_handle_search_params'); // label, function, priority  
    }

    public function user_render_search_fields ($args) {
        ?>
            <div class="field">
                <label class="label">Search id</label>
                <div class="control">
                    <input style="max-width: 10rem;" value="<?php echo $_GET["id"]; ?>" name="id" form="searchform" class="input" type="number" placeholder="">
                </div>
            </div>
        <?php
    }

    public function user_handle_search_where($search_where, $type_filter) {
        if($_SERVER["SCRIPT_URL"] != "/admin/users") {return $search_where;}

        if($_GET["id"]) {
            $search_where .= " AND u.id = ?";
        }

        return $search_where;
    }

    public function user_handle_search_params($search_params, $type_filter) {
        if($_SERVER["SCRIPT_URL"] != "/admin/users") {return $search_params;}

        if($_GET["id"]) {
            $search_params[] = $_GET["id"];
        }

        return $search_params;

    }
}
```