### PR TITLE
bug: fix tag query in content_search

### DIFF
--- a/core/content_search.php
+++ b/core/content_search.php
@@ -192,7 +192,8 @@ class Content_Search {
 			}
 			if ($tags_ok) {
 				// safe to implode without param injection
-				$where .= " and c.id in (select content_id from tagged where tag_id in (" . implode(',', $this->tags) . ")) ";
+				$where .= " and c.id in (select content_id from tagged where tag_id in (" . implode(',', $this->tags) . ") and content_type_id=?) ";
+				$this->filter_pdo_params[] = $this->type_filter;
 			}
 		}
 


### PR DESCRIPTION
bug existed since flat - can potentially return ids of current content type that are not tagged if there's a collision with an id of another content_type that _is_ tagged