### PR TITLE
chore: fix warning in navigation so that you can actually use it when warning spam is on

### DIFF
--- a/core/component.php
+++ b/core/component.php
@@ -122,7 +122,8 @@ class Component {
 
         //render the nav
         foreach($navigation as $label=>$config) {
-            if (Access::can_access(Admin_Config::$access[$label])) {
+            //setting this explicitly to null to solve the following warning spam: Undefined array key "$key" in $filepath
+            if (Access::can_access(Admin_Config::$access[$label] ?? null)) {
                 if($config["type"]=="addition_menu") {
                     Component::render_admin_nav_menu($config["menu"]);
                 } elseif($config["type"]=="addition_link") {


### PR DESCRIPTION
does what it says on the tin