### PR TITLE
chore: change up usage of adminpath to avoid death by warnings

### DIFF
--- a/admin/controllers/categories/views/edit/model.php
+++ b/admin/controllers/categories/views/edit/model.php
@@ -35,7 +35,7 @@ else {
 
 
 // prep forms
-$required_details_form = new Form(ADMINPATH . '/controllers/categories/views/edit/required_fields_form.json');
+$required_details_form = new Form(CMSPATH . '/admin/controllers/categories/views/edit/required_fields_form.json');
 // set content_type for tag field based on content type of new/editing content
 
 $content_location = Content::get_content_location($cat->content_type);

--- a/admin/controllers/content/views/check/model.php
+++ b/admin/controllers/content/views/check/model.php
@@ -12,7 +12,7 @@ foreach ($all_content_types as $content_type) {
     // create table/columns as necessary
     $location = Content::get_content_location($content_type->id);
     $custom_fields = JSON::load_obj_from_file(CMSPATH . '/controllers/' . $location . '/custom_fields.json');
-    $required_details_form = new Form(ADMINPATH . '/controllers/content/views/edit/required_fields_form.json');
+    $required_details_form = new Form(CMSPATH . '/admin/controllers/content/views/edit/required_fields_form.json');
 
 
     $response.="<hr><p>Checking table &ldquo;{$content_type->title}&rdquo;</p>";

--- a/admin/controllers/content/views/edit/model.php
+++ b/admin/controllers/content/views/edit/model.php
@@ -36,7 +36,7 @@ CMS::Instance()->editing_content = $content;
 
 // inject custom content states into form
 $custom_fields = json_decode(file_get_contents(CMSPATH . '/controllers/' . $content->content_location . "/custom_fields.json"));
-$required_details_obj = json_decode(file_get_contents(ADMINPATH . '/controllers/content/views/edit/required_fields_form.json'));
+$required_details_obj = json_decode(file_get_contents(CMSPATH . '/admin/controllers/content/views/edit/required_fields_form.json'));
 
 $required_details_obj = Hook::execute_hook_filters('content_required_details_form_obj', $required_details_obj);
 

--- a/admin/controllers/images/views/edit/model.php
+++ b/admin/controllers/images/views/edit/model.php
@@ -19,7 +19,7 @@ else {
 }
 
 // prep forms
-$required_details_form = new Form(ADMINPATH . '/controllers/tags/views/edit/required_fields_form.json');
+$required_details_form = new Form(CMSPATH . '/admin/controllers/tags/views/edit/required_fields_form.json');
 
 
 // check if submitted or show defaults/data from db

--- a/admin/controllers/pages/views/edit/model.php
+++ b/admin/controllers/pages/views/edit/model.php
@@ -41,7 +41,7 @@ $template = $default_template;
 // if page_id exists, try and override form content 
 
 $page = new Page();
-$page_options_form = new Form(ADMINPATH . '/controllers/pages/page_options.json');
+$page_options_form = new Form(CMSPATH . '/admin/controllers/pages/page_options.json');
 
 //CMS::pprint_r (CMS::Instance()->uri_segments);
 if (array_key_exists(2, CMS::Instance()->uri_segments)) {

--- a/admin/controllers/pages/views/save/model.php
+++ b/admin/controllers/pages/views/save/model.php
@@ -4,7 +4,7 @@ defined('CMSPATH') or die; // prevent unauthorized access
 // any variables created here will be available to the view
 
 $page = new Page();
-$page_options_form = new Form(ADMINPATH . '/controllers/pages/page_options.json');
+$page_options_form = new Form(CMSPATH . '/admin/controllers/pages/page_options.json');
 $success=$page->load_from_post();
 
 if (!$success) {

--- a/admin/controllers/redirects/views/edit/model.php
+++ b/admin/controllers/redirects/views/edit/model.php
@@ -18,7 +18,7 @@ else {
 	exit(0);
 }
 
-$required_details_obj = json_decode(file_get_contents(ADMINPATH . '/controllers/redirects/views/edit/required_fields_form.json'));
+$required_details_obj = json_decode(file_get_contents(CMSPATH . '/admin/controllers/redirects/views/edit/required_fields_form.json'));
 foreach($required_details_obj->fields as $field) {
 	if($field->name == "state") {
 		foreach($custom_fields->states as $state) {

--- a/admin/controllers/tags/views/edit/model.php
+++ b/admin/controllers/tags/views/edit/model.php
@@ -19,7 +19,7 @@ else {
 }
 
 // prep forms
-$required_details_form = new Form(ADMINPATH . '/controllers/tags/views/edit/required_fields_form.json');
+$required_details_form = new Form(CMSPATH . '/admin/controllers/tags/views/edit/required_fields_form.json');
 $custom_fields_form = file_exists(CMSPATH . "/tag_fields.json");
 if ($custom_fields_form) {
 	$custom_fields_form = new Form (CMSPATH . "/tag_fields.json");

--- a/core/access.php
+++ b/core/access.php
@@ -7,8 +7,7 @@ class Access {
         if (!$user_groups) {
             $user_groups = CMS::Instance()->user->groups;
         }
-        // @phpstan-ignore-next-line
-        if (!$page_groups && ADMINPATH) {
+        if (!$page_groups && defined("ADMINPATH")) {
             // default to admin in absence of explicit admin config
             // remove sizeof check for php 8.0+
             $page_groups=[1];

--- a/core/cms.php
+++ b/core/cms.php
@@ -260,8 +260,7 @@ final class CMS {
 		// first strip base uri path (from config) out of path
 		$this->request = $_SERVER['REQUEST_URI'];
 		$to_remove = Config::uripath();
-		// @phpstan-ignore-next-line
-		if (ADMINPATH) {
+		if (defined("ADMINPATH")) {
 			$to_remove .= "/admin/";
 		}
 		$this->request = str_ireplace($to_remove, "", $this->request);
@@ -352,8 +351,7 @@ final class CMS {
 				
 				if ($session_user_id) {
 					// needs to be instance as messages not invoked yet
-					// @phpstan-ignore-next-line
-					if (ADMINPATH) {
+					if (defined("ADMINPATH")) {
 						$_SESSION['redirect_url'] = "//{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";
 						CMS::Instance()->queue_message('You were logged out due to inactivity.','danger',Config::uripath() . '/admin');
 					}
@@ -391,8 +389,7 @@ final class CMS {
 		// small performance hit, but only way to alleviate potential security issues for following checks
 
 		// check for core controller - save folder name if found for include during rendering
-		// @phpstan-ignore-next-line
-		if(!ADMINPATH) {
+		if(!defined("ADMINPATH")) {
 			foreach(scandir(CMSPATH . "/core/controllers") as $folder) {
 				if($this->uri_segments[0] == $folder) {
 					$this->core_controller = $folder;
@@ -400,8 +397,8 @@ final class CMS {
 				}
 			}
 		}
-		// @phpstan-ignore-next-line
-		if ( !Config::debugwarnings() && !Config::debug() && Config::caching() && !ADMINPATH && !($_SESSION['flash_messages'] ?? null) && !$this->user->id && !$this->core_controller)  {
+
+		if ( !Config::debugwarnings() && !Config::debug() && Config::caching() && !defined("ADMINPATH") && !($_SESSION['flash_messages'] ?? null) && !$this->user->id && !$this->core_controller)  {
 			// check if caching is turned on and we are on front-end 
 			// admin will never create caches, so no point in even checking
 			// also never serve cache if messages waiting to be viewed potentially
@@ -425,7 +422,6 @@ final class CMS {
 		echo "<p>Domain: {$this->domain}</p>";
 		echo "<p>Base Path (subfolder): " . Config::uripath() . "</p>";
 		echo "<p>CMSPATH: " . CMSPATH . "</p>";
-		echo "<p>ADMINPATH: " . ADMINPATH . "</p>";
 		echo "<p>Default template: " . Config::template() . "</p>";
 		echo "<p>User:<p>";
 		$this->pprint_r($this->user);
@@ -469,8 +465,7 @@ final class CMS {
 		// returns name/location of controller (if any)
 		// if controller found, it is set in $this->page->controller object
 		// called by render_controller function
-		// @phpstan-ignore-next-line
-		if (ADMINPATH) {
+		if (defined("ADMINPATH")) {
 			// works different here boys and girls
 			// controller name is first part of segment
 			// todo: lookup in db first? make sure it's installed?
@@ -581,15 +576,13 @@ final class CMS {
 		//$this->include_once_content (CMSPATH .'/templates/' . $template . '/index.php');
 		// if ADMIN but guest, show login
 	
-		// @phpstan-ignore-next-line
-		if ( (ADMINPATH && $this->user->username=="guest") || ($this->user->username=="guest" && Config::frontendlogin()) ) {
+		if ( (defined("ADMINPATH") && $this->user->username=="guest") || ($this->user->username=="guest" && Config::frontendlogin()) ) {
 			// check for login attempt
 			$email = Input::getvar('email','EMAIL'); // note: php email filter is a bit more picky than html input type email
 			$password = Input::getvar('password','RAW');
 			$login_user = new User();
 			$redirect_path = Config::uripath() . "/";
-			// @phpstan-ignore-next-line
-			if (ADMINPATH) {
+			if (defined("ADMINPATH")) {
 				$redirect_path = Config::uripath() . '/admin';
 			}
 
@@ -644,8 +637,7 @@ final class CMS {
 					$this->queue_message('Incorrect email or password','danger', $redirect_path);
 				}
 			}
-			// @phpstan-ignore-next-line
-			if (ADMINPATH) {
+			if (defined("ADMINPATH")) {
 				// force switch to admin template login 
 				$template = $this->get_admin_template();
 			}
@@ -656,8 +648,7 @@ final class CMS {
 		}
 
 		else {
-			// @phpstan-ignore-next-line
-			if (ADMINPATH) {
+			if (defined("ADMINPATH")) {
 				//check the users access rights
 				if (!Access::can_access(Admin_Config::$access[$this->uri_segments[0]])) {
 					if(CMS::Instance()->user && CMS::Instance()->user->groups && (CMS::Instance()->user->is_member_of(1) || CMS::Instance()->user->is_member_of(2))) {

--- a/core/component.php
+++ b/core/component.php
@@ -88,7 +88,7 @@ class Component {
     public static function render_admin_nav($navigation, $enable_overrides=true) {
         //apply overrides from admin config if applicable
         if($enable_overrides) {
-            //@phpstan-ignore-next-line
+            // @phpstan-ignore-next-line
             $overrides = property_exists('Admin_Config',"navigation") ? Admin_Config::$navigation : [];
             $addons = [];
 

--- a/core/content.php
+++ b/core/content.php
@@ -88,15 +88,13 @@ class Content {
 				if ($this->id) {
 					// add id to alias to make unique for existing content item
 					$this->alias = $this->alias . "-" . $this->id;
-					// @phpstan-ignore-next-line
-					if (ADMINPATH) {
+					if (defined("ADMINPATH")) {
 						CMS::Instance()->queue_message('Added content id as suffix to "URL Friendly" field to ensure uniqueness.','warning');
 					}
 				}
 				else {
 					$this->alias = $this->alias . "-" . uniqid();
-					// @phpstan-ignore-next-line
-					if (ADMINPATH) {
+					if (defined("ADMINPATH")) {
 						CMS::Instance()->queue_message('Added random suffix to "URL Friendly" field to ensure uniqueness.','warning');
 					}
 				}

--- a/core/fields/Field_Parsedown.php
+++ b/core/fields/Field_Parsedown.php
@@ -544,8 +544,7 @@ class Field_Parsedown extends Field {
 		$this->default = $config->default ?? '### New Text';
 		$this->placeholder = $config->placeholder ?? '';
 		$this->parsedownapi = $config->parsedownapi ?? "/api/parsedown";
-		// @phpstan-ignore-next-line
-		$this->imageapi = property_exists($config, "imageapi") ? $config->imageapi : (ADMINPATH ? "/admin/images/uploadv2" : null);
+		$this->imageapi = property_exists($config, "imageapi") ? $config->imageapi : (defined("ADMINPATH") ? "/admin/images/uploadv2" : null);
 		/*
 			if the property exists, use it even if null(disabled)
 			else fallback to:

--- a/core/widget.php
+++ b/core/widget.php
@@ -18,8 +18,7 @@ class Widget {
 	public $form_data;
 
 	public function render_edit() {
-		// @phpstan-ignore-next-line
-		if (CMS::Instance()->user->is_member_of(1) && !ADMINPATH) { ?>
+		if (CMS::Instance()->user->is_member_of(1) && !defined("ADMINPATH")) { ?>
 			<div class='front_end_edit_wrap' >
 				<a style='' target="_blank" href='/admin/widgets/edit/<?php echo $this->id;?>'>EDIT &ldquo;<?= htmlspecialchars($this->title); ?>&rdquo;</a>
 			</div>

--- a/index.php
+++ b/index.php
@@ -2,7 +2,6 @@
 // define CMSPATH - used as test definition in ALL php files to determine
 // if CMS is loaded or not	
 define ("CMSPATH", realpath(dirname(__FILE__)));
-define ("ADMINPATH",false);
 define ("CURPATH",CMSPATH);
 
 //handle composer dependencies

--- a/plugins/core_frontend_editbutton/plugin_class.php
+++ b/plugins/core_frontend_editbutton/plugin_class.php
@@ -36,8 +36,7 @@ class Plugin_core_frontend_editbutton extends Plugin {
 
     public function handle_widget_render($page_contents, $params) {
         $data = $this->get_data();
-        // @phpstan-ignore-next-line
-        if($this->validateGroup($data->groupOptionsArray, $data->userGroups) && !ADMINPATH) {
+        if($this->validateGroup($data->groupOptionsArray, $data->userGroups) && !defined("ADMINPATH")) {
             if(Config::enable_experimental_frontend_edit() ?? false) {
                 $page_contents = "
                     <div class='front_end_edit_wrap' >
@@ -60,7 +59,7 @@ class Plugin_core_frontend_editbutton extends Plugin {
     public function handle_controller_render($page_contents, $params) {
         $data = $this->get_data();
 
-        if($this->validateGroup($data->groupOptionsArray, $data->userGroups) && (Config::enable_experimental_frontend_edit() ?? false) && ADMINPATH===false){
+        if($this->validateGroup($data->groupOptionsArray, $data->userGroups) && (Config::enable_experimental_frontend_edit() ?? false) && !defined("ADMINPATH")){
             $controllerConfig = DB::fetch("SELECT * FROM content_types WHERE controller_location = ?", $params[0]);
             $page_contents = "
                 <div class='front_end_edit_wrap' >


### PR DESCRIPTION
does what it says on the tin

NOTES:
* removes ADMINPATH from index.php
* reduces our `// @phpstan-ignore-next-line` count to 5 lines
* gets rid of 15 instances of `// @phpstan-ignore-next-line`
* our two ignore errors remain unchanged