### PR TITLE
fix: remove redundant 'value' attribute from textarea

### DIFF
--- a/core/fields/Field_Textarea.php
+++ b/core/fields/Field_Textarea.php
@@ -31,7 +31,7 @@ class Field_Textarea extends Field {
 			echo "<label for='{$this->id}' class='label'>{$this->label}</label>";
 			echo "<div class='control' data-value='{$this->default}'>";
 				$this->default = str_replace("[NEWLINE]","\n",$this->default);
-				echo "<textarea oninput='this.parentNode.dataset.value = this.value;' type='{$this->input_type}' value='{$this->default}' maxlength={$this->maxlength} placeholder='{$this->placeholder}' minlength={$this->minlength} class='filter_{$this->filter} input autogrowingtextarea' {$required} type='text' id='{$this->id}' {$this->get_rendered_name()}>";
+				echo "<textarea oninput='this.parentNode.dataset.value = this.value;' type='{$this->input_type}' maxlength={$this->maxlength} placeholder='{$this->placeholder}' minlength={$this->minlength} class='filter_{$this->filter} input autogrowingtextarea' {$required} type='text' id='{$this->id}' {$this->get_rendered_name()}>";
 				echo $this->default;
 				echo "</textarea>";
 			echo "</div>";


### PR DESCRIPTION
Remove redundant 'value' attribute from textarea that caused errors with special characters. 