### PR TITLE
chore: add a check before looping core controllers to prevent core controller number of warnings on home page

### DIFF
--- a/core/cms.php
+++ b/core/cms.php
@@ -390,10 +390,12 @@ final class CMS {
 
 		// check for core controller - save folder name if found for include during rendering
 		if(!defined("ADMINPATH")) {
-			foreach(scandir(CMSPATH . "/core/controllers") as $folder) {
-				if($this->uri_segments[0] == $folder) {
-					$this->core_controller = $folder;
-					break;
+			if(sizeof($this->uri_segments)>0) {
+				foreach(scandir(CMSPATH . "/core/controllers") as $folder) {
+					if($this->uri_segments[0] == $folder) {
+						$this->core_controller = $folder;
+						break;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
does what it says on the tin