### PR TITLE
admin header refactoring and unification

### DIFF
--- a/admin/controllers/audit/views/default/style.css
+++ b/admin/controllers/audit/views/default/style.css
@@ -3,7 +3,6 @@
     grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
     gap: 0.5rem 2rem;
     width: 100%;
-    padding-bottom: 2rem;
     align-items: end;
 
     .field {

--- a/admin/controllers/audit/views/default/view.php
+++ b/admin/controllers/audit/views/default/view.php
@@ -4,9 +4,9 @@ defined('CMSPATH') or die; // prevent unauthorized access
 echo "<style>";
     echo file_get_contents(CMSPATH . "/admin/controllers/audit/views/default/style.css");
 echo "</style>";
-?>
 
-<h1 class="title is-1">Audit Log</h1>
+Component::addon_page_title("Audit Log");
+?>
 
 <br>
 

--- a/admin/controllers/categories/views/all/style.css
+++ b/admin/controllers/categories/views/all/style.css
@@ -14,9 +14,6 @@ span.position_single {
 span.page_list, td.note_td, .lighter_note, .usage {
 	font-size:70%; opacity:0.6;
 }
-#content_operations {
-	margin-right:2rem;
-}
 .state1 {
 	color:#00d1b2;
 }

--- a/admin/controllers/categories/views/all/view.php
+++ b/admin/controllers/categories/views/all/view.php
@@ -8,40 +8,39 @@ defined('CMSPATH') or die; // prevent unauthorized access
 
 <form id='searchform' action="" method="GET"></form>
 
-<form action='' method='post' name='content_action' id='content_action_form'>
-<input type='hidden' name='content_type' value='<?=$content_type_filter;?>'/>
-<h1 class='title is-1'>All <?php if ($content_type_filter) { echo "&ldquo;" . Content::get_content_type_title($content_type_filter) . "&rdquo; ";}?>Categories
-	<?php if ($content_type_filter):?>
+<?php
+	ob_start();
+	if ($content_type_filter) {
+?>
 	<a class='is-primary pull-right button btn' href='<?php echo Config::uripath();?>/admin/categories/edit/new/<?php echo $content_type_filter;?>'>New &ldquo;<?php echo Content::get_content_type_title($content_type_filter);?>&rdquo; Category</a>
-	
-	<?php else: ?>
-		<div class='field pull-right'>
-			<label class='label'>New Category</label>
-			<div class='control'>
-				<div class='select'>
-					<select onchange="choose_new_content_type();" data-widget_type_id='0' id='new_content_type_selector'>
-						<option value='666'>Make selection:</option>
-						<?php foreach ($all_content_types as $content_type):?>
+<?php
+	} else {
+?>
+	<div class='field pull-right'>
+		<label class='label'>New Category</label>
+		<div class='control'>
+			<div class='select'>
+				<select onchange="choose_new_content_type();" data-widget_type_id='0' id='new_content_type_selector'>
+					<option value='666'>Make selection:</option>
+					<?php foreach ($all_content_types as $content_type):?>
 						<option value='<?php echo $content_type->id;?>'><?php echo $content_type->title;?></option>
-						<?php endforeach; ?>
-					</select>
-					<script>
+					<?php endforeach; ?>
+				</select>
+				<script>
 					function choose_new_content_type() {
 						new_id = document.getElementById("new_content_type_selector").value;
 						window.location.href = "<?php echo Config::uripath();?>/admin/categories/edit/new/" + new_id;
 					}
-					</script>
-				</div>
+				</script>
 			</div>
 		</div>
-	<?php endif; ?>
-	<!-- content operation toolbar -->
-	<div id="content_operations" class="pull-right buttons has-addons">
-		<button formaction='<?php echo Config::uripath();?>/admin/categories/action/publish' class='button is-primary' type='submit'>Publish</button>
-		<button formaction='<?php echo Config::uripath();?>/admin/categories/action/unpublish' class='button is-warning' type='submit'>Unpublish</button>
-		<button formaction='<?php echo Config::uripath();?>/admin/categories/action/delete' onclick='return window.confirm("Are you sure?")' class='button is-danger' type='submit'>Delete</button>
 	</div>
-</h1>
+<?php
+	}
+	$rightContent = ob_get_clean();
+	$header = "All Categories";
+	Component::addon_page_title($header, null, $rightContent);
+?>
 
 	<div class="field has-addons">
 		<div class="control">
@@ -59,7 +58,12 @@ defined('CMSPATH') or die; // prevent unauthorized access
 		</div>
 	</div>
 
-
+<form action='' method='post' name='content_action' id='content_action_form'>
+<input type='hidden' name='content_type' value='<?=$content_type_filter;?>'/>
+<?php
+	$addonButtonGroupArgs = ["content_operations", "categories"];
+	Component::addon_button_toolbar($addonButtonGroupArgs);
+?>
 
 <?php if (!$all_categories):?>
 	<h2>No categories to show!</h2>
@@ -120,3 +124,8 @@ defined('CMSPATH') or die; // prevent unauthorized access
 <?php endif; ?>
 
 </form>
+
+<script type="module">
+	import {handleAdminRows} from "/core/js/admin_row.js";
+	handleAdminRows(".content_admin_row");
+</script>

--- a/admin/controllers/categories/views/edit/view.php
+++ b/admin/controllers/categories/views/edit/view.php
@@ -34,7 +34,9 @@ defined('CMSPATH') or die; // prevent unauthorized access
 	<?php echo file_get_contents(CMSPATH . "/admin/controllers/categories/views/edit/style.css"); ?>
 </style>
 
-
-<button class='button is-primary' type='submit'>Save</button>
+<div class="fixed-control-bar">
+	<button class='button is-primary' type='submit'>Save</button>
+	<button class="button is-warning" type="button" onclick="window.history.back();">Cancel</button>
+</div>
 </form>
 

--- a/admin/controllers/content/views/all/style.css
+++ b/admin/controllers/content/views/all/style.css
@@ -15,9 +15,6 @@ span.page_list, td.note_td, .lighter_note, .usage {
 	font-size:70%; opacity:0.6;
 }
 
-#content_operations {
-	margin-right:2rem;
-}
 .state1 {
 	color:#00d1b2;
 }

--- a/admin/controllers/content/views/all/view.php
+++ b/admin/controllers/content/views/all/view.php
@@ -23,8 +23,6 @@ defined('CMSPATH') or die; // prevent unauthorized access
 	}
 </style>
 
-<form id='searchform' action="" method="GET"></form>
-
 <?php
 	$content_type_fields = Content::get_content_type_fields($content_type_filter);
 
@@ -34,6 +32,7 @@ defined('CMSPATH') or die; // prevent unauthorized access
 	Component::addon_page_title($header, $byline, $rightContent);
 ?>
 
+<form id='searchform' action="" method="GET" style="margin: 0;">
 	<div id='content_search_controls' class='flex'>
 
 		<div class="field">
@@ -128,6 +127,7 @@ defined('CMSPATH') or die; // prevent unauthorized access
 
 		
 	</div>
+</form>
 
 <?php if (!$all_content):?>
 	<h2>No content to show!</h2>

--- a/admin/controllers/content/views/all/view.php
+++ b/admin/controllers/content/views/all/view.php
@@ -24,17 +24,15 @@ defined('CMSPATH') or die; // prevent unauthorized access
 </style>
 
 <form id='searchform' action="" method="GET"></form>
-<form id='orderform' action="" methpd="GET"></form>
 
-<form action='' method='post' name='content_action' id='content_action_form'>
-<input type='hidden' name='content_type' value='<?=$content_type_filter;?>'/>
-<h1 class='title is-1'>All <?php echo "&ldquo;" . Content::get_content_type_title($content_type_filter) . "&rdquo; ";?>Content
-	<a class='is-primary pull-right button btn' href='<?php echo Config::uripath();?>/admin/content/edit/new/<?php echo $content_type_filter;?>'>New &ldquo;<?php echo Content::get_content_type_title($content_type_filter);?>&rdquo; Content</a>
-	<span class='unimportant subheading'><?php $content_type_fields = Content::get_content_type_fields($content_type_filter);  echo $content_type_fields->description; ?></span>
-	<?php Component::addon_button_group("content_operations", "content", ["publish"=>"primary","unpublish"=>"warning","duplicate"=>"info","delete"=>"danger"]); ?>
-</h1>
+<?php
+	$content_type_fields = Content::get_content_type_fields($content_type_filter);
 
-	<?php //CMS::pprint_r ($filters); ?>
+	$header = "All &ldquo;" . Content::get_content_type_title($content_type_filter) . "&rdquo; Content";
+	$byline = $content_type_fields->description;
+	$rightContent = "<a class='is-primary button btn' href='" . Config::uripath() . "/admin/content/edit/new/$content_type_filter'>New &ldquo;" . Content::get_content_type_title($content_type_filter) . "&rdquo; Content</a>";
+	Component::addon_page_title($header, $byline, $rightContent);
+?>
 
 	<div id='content_search_controls' class='flex'>
 
@@ -134,8 +132,15 @@ defined('CMSPATH') or die; // prevent unauthorized access
 <?php if (!$all_content):?>
 	<h2>No content to show!</h2>
 <?php else:?>
+	<form style="margin: 0;" id='orderform' action="" methpd="GET"></form>
 
-	<a class='button is-primary is-outlined is-small' href='<?php echo Config::uripath() . "/admin/content/order/{$content_type_filter}";?>'>MANAGE ORDERING</a>
+	<form action='' method='post' name='content_action' id='content_action_form'>
+	<input type='hidden' name='content_type' value='<?=$content_type_filter;?>'/>
+	<?php
+		$leftContent = "<a class='button is-primary is-outlined is-small' href='" . Config::uripath() . "/admin/content/order/{$content_type_filter}'>MANAGE ORDERING</a>";
+		$addonButtonGroupArgs = ["content_operations", "content", ["publish"=>"primary","unpublish"=>"warning","duplicate"=>"info","delete"=>"danger"]];
+		Component::addon_button_toolbar($addonButtonGroupArgs, $leftContent);
+	?>
 
 	<table class='table'>
 		<thead>

--- a/admin/controllers/forms/views/submissions/view.php
+++ b/admin/controllers/forms/views/submissions/view.php
@@ -17,7 +17,8 @@ $urlQueryParams["exportcsv"]=1;
 $urlPath = parse_url($_SERVER["REQUEST_URI"], PHP_URL_PATH);
 $exportUrl = $urlPath . "?" . http_build_query($urlQueryParams);
 
-echo "<h1 style='display: flex; justify-content: space-between;' class='title is-1'>$titleText <a href='$exportUrl' class='button'>Export All</a></h1>";
+$rightContent = "<a href='$exportUrl' class='button'>Export All</a>";
+Component::addon_page_title($titleText, null, $rightContent);
 
 echo "<form>";
     $searchFieldsForm->display_front_end();

--- a/admin/controllers/pages/views/default/view.php
+++ b/admin/controllers/pages/views/default/view.php
@@ -6,18 +6,22 @@ defined('CMSPATH') or die; // prevent unauthorized access
 	<?php echo file_get_contents(CMSPATH . "/admin/controllers/pages/views/default/style.css"); ?>
 </style>
 
-<form action='' method='post' name='page_action' id='page_action_form'>
-
-	<h1 class='title is-1'>
-		All Pages
-		<a href='<?php echo Config::uripath() . "/admin/pages/edit/0"?>' class="button is-primary pull-right">
-			<span class="icon is-small">
-				<i class="fas fa-check"></i>
+<?php
+	$header = "All Pages";
+	$rightContent = "<a href='" . Config::uripath() . "/admin/pages/edit/0' class='button is-primary pull-right'>
+			<span class='icon is-small'>
+				<i class='fas fa-check'></i>
 			</span>
 			<span>New Page</span>
-		</a>
-		<?php Component::addon_button_group("page_operations", "pages"); ?>
-	</h1>
+		</a>";
+	Component::addon_page_title($header, null, $rightContent);
+?>
+
+<form action='' method='post' name='page_action' id='page_action_form'>
+	<?php
+		$addonButtonGroupArgs = ["page_operations", "pages"];
+		Component::addon_button_toolbar($addonButtonGroupArgs);
+	?>
 
 	<table id='all_pages_table' class="table">
 		<thead>

--- a/admin/controllers/plugins/views/show/view.php
+++ b/admin/controllers/plugins/views/show/view.php
@@ -5,11 +5,13 @@ defined('CMSPATH') or die; // prevent unauthorized access
 	<?php echo file_get_contents(CMSPATH . "/admin/controllers/plugins/views/show/style.css"); ?>
 </style>
 
+<?php Component::addon_page_title("Plugins"); ?>
+	
 <form action='' method='post' name='plugin_action' id='plugin_action_form'>
-
-	<h1 class='title'>Plugins
-		<?php Component::addon_button_group("plugin_operations", "plugins"); ?>
-	</h1>
+	<?php
+		$addonButtonGroupArgs = ["plugin_operations", "plugins"];
+		Component::addon_button_toolbar($addonButtonGroupArgs);
+	?>
 
 	<table class='table'>
 		<thead>

--- a/admin/controllers/redirects/views/all/style.css
+++ b/admin/controllers/redirects/views/all/style.css
@@ -15,10 +15,6 @@ span.page_list, td.note_td, .lighter_note, .usage {
 	font-size:70%; opacity:0.6;
 }
 
-
-#content_operations {
-	margin-right:2rem;
-}
 .state1 {
 	color:#00d1b2;
 }

--- a/admin/controllers/redirects/views/all/view.php
+++ b/admin/controllers/redirects/views/all/view.php
@@ -8,20 +8,10 @@ defined('CMSPATH') or die; // prevent unauthorized access
 
 <form id='searchform' action="" method="GET"></form>
 
-
-
-<form action='' method='post' name='redirect_action' id='redirect_action_form'>
-<h1 class='title is-1'>Redirects
-	<a class='is-primary pull-right button btn' href='<?php echo Config::uripath();?>/admin/redirects/edit/new'>New Redirect</a>
-	<!-- content operation toolbar -->
-	<div id="content_operations" class="pull-right buttons has-addons">
-		<button formaction='<?php echo Config::uripath();?>/admin/redirects/action/publish' class='button is-primary' type='submit'>Publish</button>
-		<button formaction='<?php echo Config::uripath();?>/admin/redirects/action/unpublish' class='button is-warning' type='submit'>Unpublish</button>
-		<button formaction='<?php echo Config::uripath();?>/admin/redirects/action/delete' onclick='return window.confirm("Are you sure?")' class='button is-danger' type='submit'>Delete</button>
-	</div>
-</h1>
-
-	<?php //CMS::pprint_r ($filters); ?>
+<?php
+	$rightContent = "<a class='is-primary pull-right button btn' href='" . Config::uripath() . "/admin/redirects/edit/new'>New Redirect</a>";
+	Component::addon_page_title("Redirects", null, $rightContent);
+?>
 
 	<div id='content_search_controls' class='flex'>
 
@@ -51,12 +41,6 @@ defined('CMSPATH') or die; // prevent unauthorized access
 				</div>
 			</div>
 		</div>
-
-		<script>
-		new SlimSelect({
-			select:'#content_search_tags'
-		});
-		</script>
 		
 		<div class='field'>
 			<label class="label">&nbsp;</label>
@@ -79,11 +63,12 @@ defined('CMSPATH') or die; // prevent unauthorized access
 		
 	</div>
 
+<form action='' method='post' name='redirect_action' id='redirect_action_form'>
 
-	
-	
-
-
+<?php
+	$addonButtonGroupArgs = ["content_operations", "redirects"];
+	Component::addon_button_toolbar($addonButtonGroupArgs);
+?>
 
 <?php if (!$redirects):?>
 	<h2>No redirects found.</h2>

--- a/admin/controllers/settings/views/backups/view.php
+++ b/admin/controllers/settings/views/backups/view.php
@@ -1,8 +1,8 @@
 <?php
 defined('CMSPATH') or die; // prevent unauthorized access
-?>
-<h1 class='title is-1'>Backups</h1>
 
+Component::addon_page_title("Backups");
+?>
 
 <?php if (class_exists("ZipArchive",false)):?>
 	<form method="POST">

--- a/admin/controllers/settings/views/general/view.php
+++ b/admin/controllers/settings/views/general/view.php
@@ -1,7 +1,8 @@
 <?php
 defined('CMSPATH') or die; // prevent unauthorized access
+
+Component::addon_page_title("General Options");
 ?>
-<h1 class='title is-1'>General Options</h1>
 
 <?php 
 //$debug = Configuration::get_configuration_value('general_options','debug'); CMS::pprint_r ($debug);

--- a/admin/controllers/settings/views/info/view.php
+++ b/admin/controllers/settings/views/info/view.php
@@ -48,12 +48,7 @@ function embedded_phpinfo()
         ";
 }
 
-?>
-
-<h1 class='title is-1'>System Information</h1>
-
-<?php 
-
+Component::addon_page_title("System Information");
 
 if ($native_zip) {
 	show_message ('Native Zip','Native zip handling is available. This is required for automatic update installation.','is-success');

--- a/admin/controllers/settings/views/updates/view.php
+++ b/admin/controllers/settings/views/updates/view.php
@@ -13,8 +13,8 @@ function show_message ($heading, $text, $class) {
 </article>";
 }
 
+Component::addon_page_title("System Version and Updates");
 ?>
-<h1 class='title is-1'>System Version and Updates</h1>
 <h4 class='title is-4'>Current <?=$channel;?> version: <?php echo CMS::Instance()->version;?></h4>
 <?php if ( $latest_version_current_channel == CMS::Instance()->version ):?>
 	<h5 class='title is-5'>You are on the latest version!</h4>

--- a/admin/controllers/tags/views/show/view.php
+++ b/admin/controllers/tags/views/show/view.php
@@ -7,17 +7,11 @@ defined('CMSPATH') or die; // prevent unauthorized access
 
 <form id='searchform' action="" method="GET"></form>
 
-<form action='' method='post' name='tag_action' id='tag_action_form'>
-
-	<h1 class='title'>All Tags
-		<a class='pull-right button is-primary' href='<?php echo Config::uripath();?>/admin/tags/edit/new'>New Tag</a>
-		<!-- tag operation toolbar -->
-		<div id="tag_operations" class="pull-right buttons has-addons">
-			<button formaction='<?php echo Config::uripath();?>/admin/tags/action/publish' class='button is-primary' type='submit'>Publish</button>
-			<button formaction='<?php echo Config::uripath();?>/admin/tags/action/unpublish' class='button is-warning' type='submit'>Unpublish</button>
-			<button formaction='<?php echo Config::uripath();?>/admin/tags/action/delete' onclick='return window.confirm("Are you sure?")' class='button is-danger' type='submit'>Delete</button>
-		</div>
-	</h1>
+<?php
+	$header = "All Tags";
+	$rightContent = "<a class='pull-right button is-primary' href='" . Config::uripath() ."/admin/tags/edit/new'>New Tag</a>";
+	Component::addon_page_title($header, null, $rightContent);
+?>
 
 	<div id='tag_search_controls' class='flex'>
 
@@ -47,6 +41,11 @@ defined('CMSPATH') or die; // prevent unauthorized access
 		</div>
 
 	</div>
+<form action='' method='post' name='tag_action' id='tag_action_form'>
+	<?php
+		$addonButtonGroupArgs = ["tag_operations", "tags"];
+		Component::addon_button_toolbar($addonButtonGroupArgs);
+	?>
 
 	<table class='table'>
 		<thead>

--- a/admin/controllers/users/views/default/style.css
+++ b/admin/controllers/users/views/default/style.css
@@ -12,11 +12,6 @@ span.position_single {
     font-weight:bold;
 }
 
-
-
-#user_operations {
-    margin-right:2rem;
-}
 .state1 {
     color:#00d1b2;
 }

--- a/admin/controllers/users/views/default/view.php
+++ b/admin/controllers/users/views/default/view.php
@@ -6,7 +6,6 @@ defined('CMSPATH') or die; // prevent unauthorized access
 	<?php echo file_get_contents(CMSPATH . "/admin/controllers/users/views/default/style.css"); ?>
 </style>
 
-<form id='searchform' action="" method="GET"></form>
 <?php
 	$header = "Users: " . $group_name;
 	$rightContent = "<a href='" . Config::uripath() . "/admin/users/edit' class='button is-primary pull-right'>
@@ -18,6 +17,7 @@ defined('CMSPATH') or die; // prevent unauthorized access
 	Component::addon_page_title($header, null, $rightContent);
 ?>
 
+<form id='searchform' action="" method="GET" style="margin: 0;">
 	<div id='content_search_controls' class='flex'>
 
 		<div class="field">
@@ -99,6 +99,8 @@ defined('CMSPATH') or die; // prevent unauthorized access
 			</div>
 		</div>
 	</div>
+</form>
+
 <form action='' method='post' name='user_action' id='user_action_form'>
 	<?php
 		$addonButtonGroupArgs = ["user_operations", "users", ["publish"=>"primary","unpublish"=>"warning","duplicate"=>"info","delete"=>"danger"]];

--- a/admin/controllers/users/views/default/view.php
+++ b/admin/controllers/users/views/default/view.php
@@ -7,23 +7,16 @@ defined('CMSPATH') or die; // prevent unauthorized access
 </style>
 
 <form id='searchform' action="" method="GET"></form>
-
-<form action='' method='post' name='user_action' id='user_action_form'>
-	<h1 class='title is-1'>
-		Users: <?php echo $group_name; ?>
-		<a href='<?php echo Config::uripath() . "/admin/users/edit"?>' class="button is-primary pull-right">
-			<span class="icon is-small">
-				<i class="fas fa-check"></i>
-			</span>
-			<span>New User</span>
-		</a>
-		<!-- user operation toolbar -->
-		<div id="user_operations" class="pull-right buttons has-addons">
-			<button formaction='<?php echo Config::uripath();?>/admin/users/action/publish' class='button is-primary' type='submit'>Publish</button>
-			<button formaction='<?php echo Config::uripath();?>/admin/users/action/unpublish' class='button is-warning' type='submit'>Unpublish</button>
-			<button formaction='<?php echo Config::uripath();?>/admin/users/action/delete' onclick='return window.confirm("Are you sure?")' class='button is-danger' type='submit'>Delete</button>
-		</div>
-	</h1>
+<?php
+	$header = "Users: " . $group_name;
+	$rightContent = "<a href='" . Config::uripath() . "/admin/users/edit' class='button is-primary pull-right'>
+		<span class='icon is-small'>
+			<i class='fas fa-check'></i>
+		</span>
+		<span>New User</span>
+	</a>";
+	Component::addon_page_title($header, null, $rightContent);
+?>
 
 	<div id='content_search_controls' class='flex'>
 
@@ -106,7 +99,11 @@ defined('CMSPATH') or die; // prevent unauthorized access
 			</div>
 		</div>
 	</div>
-
+<form action='' method='post' name='user_action' id='user_action_form'>
+	<?php
+		$addonButtonGroupArgs = ["user_operations", "users", ["publish"=>"primary","unpublish"=>"warning","duplicate"=>"info","delete"=>"danger"]];
+		Component::addon_button_toolbar($addonButtonGroupArgs);
+	?>
 	<table id='all_users_table' class="table">
 		<thead>
 			<th>Status</th>

--- a/admin/controllers/widgets/views/show/style.css
+++ b/admin/controllers/widgets/views/show/style.css
@@ -15,9 +15,6 @@ span.page_list, td.note_td, .lighter_note {
 	font-size:70%; opacity:0.6;
 }
 
-#widget_operations {
-	margin-right:2rem;
-}
 .state1 {
 	color:#00d1b2;
 }
@@ -37,7 +34,6 @@ span.page_list, td.note_td, .lighter_note {
     grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
     gap: 0.5rem 2rem;
     width: 100%;
-    padding-bottom: 2rem;
     align-items: end;
 
     .field {

--- a/admin/controllers/widgets/views/show/view.php
+++ b/admin/controllers/widgets/views/show/view.php
@@ -5,6 +5,37 @@ defined('CMSPATH') or die; // prevent unauthorized access
 	<?php echo file_get_contents(CMSPATH . "/admin/controllers/widgets/views/show/style.css"); ?>
 </style>
 
+<?php
+	ob_start();
+	if ($widget_type_id) {
+?>
+	<a class='is-primary pull-right button btn' href='<?php echo Config::uripath();?>/admin/widgets/edit/new/<?php echo $widget_type_id;?>'>New &ldquo;<?php echo $widget_type_title;?>&rdquo; Widget</a>
+<?php } else { ?>
+	<div class='field pull-right'>
+		<label class='label'>New Widget</label>
+		<div class='control'>
+			<div class='select'>
+				<select onchange="choose_new_widget_type();" data-widget_type_id='0' id='new_widget_type_selector'>
+					<option value='666'>Make selection:</option>
+					<?php foreach ($all_widget_types as $widget_type):?>
+						<option value='<?php echo $widget_type->id;?>'><?php echo $widget_type->title;?></option>
+					<?php endforeach; ?>
+				</select>
+				<script>
+					function choose_new_widget_type() {
+						new_id = document.getElementById("new_widget_type_selector").value;
+						window.location.href = "<?php echo Config::uripath();?>/admin/widgets/edit/new/" + new_id;
+					}
+				</script>
+			</div>
+		</div>
+	</div>
+<?php
+	}
+	$rightContent = ob_get_clean();
+	Component::addon_page_title("Widgets", null, $rightContent);
+?>
+
 <form method='post'>
 	<?php
 		$searchForm->display_front_end();
@@ -12,33 +43,10 @@ defined('CMSPATH') or die; // prevent unauthorized access
 </form>
 
 <form action='' method='post' name='widget_action' id='widget_action_form'>
-
-	<h1 class='title'><?php echo $widget_type_title; ?> Widgets
-		<?php if ($widget_type_id):?>
-			<a class='is-primary pull-right button btn' href='<?php echo Config::uripath();?>/admin/widgets/edit/new/<?php echo $widget_type_id;?>'>New &ldquo;<?php echo $widget_type_title;?>&rdquo; Widget</a>
-		<?php else: ?>
-			<div class='field pull-right'>
-				<label class='label'>New Widget</label>
-				<div class='control'>
-					<div class='select'>
-						<select onchange="choose_new_widget_type();" data-widget_type_id='0' id='new_widget_type_selector'>
-							<option value='666'>Make selection:</option>
-							<?php foreach ($all_widget_types as $widget_type):?>
-							<option value='<?php echo $widget_type->id;?>'><?php echo $widget_type->title;?></option>
-							<?php endforeach; ?>
-						</select>
-						<script>
-						function choose_new_widget_type() {
-							new_id = document.getElementById("new_widget_type_selector").value;
-							window.location.href = "<?php echo Config::uripath();?>/admin/widgets/edit/new/" + new_id;
-						}
-						</script>
-					</div>
-				</div>
-			</div>
-		<?php endif; ?>
-		<?php Component::addon_button_group("widget_operations", "widgets"); ?>
-	</h1>
+	<?php
+		$addonButtonGroupArgs = ["widget_operations", "widgets"];
+		Component::addon_button_toolbar($addonButtonGroupArgs);
+	?>
 
 	<table class='table'>
 		<thead>

--- a/admin/controllers/widgets/views/show/view.php
+++ b/admin/controllers/widgets/views/show/view.php
@@ -36,7 +36,7 @@ defined('CMSPATH') or die; // prevent unauthorized access
 	Component::addon_page_title("Widgets", null, $rightContent);
 ?>
 
-<form method='post'>
+<form method='post' style="margin-bottom: 0;">
 	<?php
 		$searchForm->display_front_end();
 	?>

--- a/admin/templates/clean/css/layout.css
+++ b/admin/templates/clean/css/layout.css
@@ -34,7 +34,7 @@ html {
 	float:right;
 }
 #main {
-	margin-top:3rem;
+	margin-top:1rem;
 }
 .navbar-item img {
     max-height: 3.75rem;
@@ -129,12 +129,6 @@ div#content_search_controls {
 }
 div#content_search_controls .field {
 	min-width:5rem;
-}
-#content_operations {
-	float:none;
-	display:flex;
-	justify-content: end;
-	margin:0 1rem;
 }
 
 html > footer {

--- a/admin/templates/clean/navigation.php
+++ b/admin/templates/clean/navigation.php
@@ -77,6 +77,8 @@ $navigation = [
             "links"=>array_merge(
                 DB::fetchall("SELECT title, CONCAT('/admin/categories/all/', id) FROM content_types", [], ["mode"=>PDO::FETCH_KEY_PAIR]),
                 ["hr"=>"hr"],
+                ["all Categories"=>"/admin/categories/all"],
+                ["hr2"=>"hr"],
                 ["tags"=>"/admin/categories/all/-3"],
             )
         ]

--- a/core/component.php
+++ b/core/component.php
@@ -73,16 +73,93 @@ class Component {
     }
 
     public static function addon_button_group($id, $location, $buttons=["publish"=>"primary","unpublish"=>"warning","delete"=>"danger"]) {
-        echo "<div id='$id' class='pull-right buttons has-addons'>";
+        echo "<div id='$id' class='buttons has-addons'>";
             foreach($buttons as $button=>$class) {
                 echo    "<button
                             formaction='" . Config::uripath() . "/admin/$location/action/$button'
-                            class='button is-$class'
+                            class='button is-$class is-small is-outlined'
                             type='submit'
                             " . ($button=="delete" ? "onclick='return window.confirm(\"Are you sure?\")'" : "") . "
                         >" . ucwords($button) . "</button>";
             }
         echo "</div>";
+    }
+
+    public static function addon_button_toolbar($addonButtonGroupArgs, $leftContent="") {
+        ?>
+            <style>
+                .addon_button_toolbar {
+                    position: sticky;
+                    top: 0;
+                    display: flex;
+                    gap: 1rem;
+                    justify-content: space-between;
+                    padding: 1rem 0;
+                    z-index: 1;
+                    background-color: var(--bulma-body-background-color);
+                }
+
+                @media only screen and (max-width: 1024px) {
+                    .addon_button_toolbar {
+                        top: calc(var(--bulma-navbar-height) + 1.4rem);
+                    }
+                }
+            </style>
+        <?php
+
+        echo "<div class='addon_button_toolbar'>";
+            echo "<div>";
+                echo $leftContent;
+            echo "</div>";
+            Component::addon_button_group(...$addonButtonGroupArgs);
+        echo "</div>";
+    }
+
+    public static function addon_page_title($header, $byline=null, $rightContent=null) {
+        ?>
+            <style>
+                .addon_page_title_wrapper {
+                    display: flex;
+                    gap: 1rem;
+                    justify-content: space-between;
+
+                    &:has(.subheading) h1 {
+                        margin-bottom: 0.5rem; 
+                    }
+
+                    &:not(.subheading) {
+                        margin-bottom: var(--bulma-block-spacing);
+                    }
+
+                    .subheading {
+                        display: block;
+                        font-size: 1.5rem;
+                        font-weight: normal;
+                    }
+                }
+
+                @media only screen and (max-width: 1024px) {
+                    .addon_page_title_wrapper {
+                        flex-direction: column;
+                    }
+                }
+            </style>
+            <div class="addon_page_title_wrapper">
+                <div>
+                    <h1 class="title is-1"><?php echo $header; ?></h1>
+                    <?php
+                        if($byline) {
+                            echo "<span class='subheading'>$byline</span>";
+                        }
+                    ?>
+                </div>
+                <?php
+                    if($rightContent) {
+                        echo "<div>$rightContent</div>";
+                    }
+                ?>
+            </div>
+        <?php
     }
 
     public static function render_admin_nav($navigation, $enable_overrides=true) {
@@ -140,7 +217,7 @@ class Component {
                 <div class="navbar-dropdown">
                     <?php
                         foreach($menu["links"] as $label=>$url) {
-                            if($label=="hr") {
+                            if($label=="hr" || $url=="hr") {
                                 echo "<hr class='dropdown-divider'>";
                             } else {
                                 echo "<a class='navbar-item' href='" . Config::uripath() . "$url'>" . ucwords($label) . "</a>";

--- a/core/component.php
+++ b/core/component.php
@@ -105,6 +105,17 @@ class Component {
                     }
                 }
             </style>
+            <script>
+                document.addEventListener("adminRowSelected", (e)=>{
+                    document.querySelectorAll("#<?php echo $addonButtonGroupArgs[0]; ?> button").forEach((el)=>{
+                        if(e.detail.counter > 0) {
+                            el.classList.remove("is-outlined");
+                        } else {
+                            el.classList.add("is-outlined");
+                        }
+                    });
+                });
+            </script>
         <?php
 
         echo "<div class='addon_button_toolbar'>";

--- a/core/js/admin_row.js
+++ b/core/js/admin_row.js
@@ -1,4 +1,6 @@
 export function handleAdminRows(elementSelector) {
+    let counter = 0;
+
     document.querySelectorAll(elementSelector).forEach(row => {
         row.addEventListener('click',(e)=> {
             const tr = e.target.closest('tr');
@@ -6,6 +8,22 @@ export function handleAdminRows(elementSelector) {
 
             tr.classList.toggle('selected');
             hidden_checkbox.checked = !hidden_checkbox.checked;
+
+            if(tr.classList.contains("selected")) {
+                counter++;
+            } else {
+                counter--;
+            }
+
+            const rowSelectedEvent = new CustomEvent("adminRowSelected", {
+                bubbles: true,
+                target: tr,
+                detail: {
+                    counter: counter,
+                },
+            });
+
+            tr.dispatchEvent(rowSelectedEvent);
         });
     });
 }


### PR DESCRIPTION
does the following
* create component for headers, ditch h1 as container, flex nicely on mobile, and make all pages use it
* create component toolbar for publish/delete/etc
* move toolbar to below search so that forms could be done sanely rather than fields bound to empty forms above, etc
* fix categories so that rows could be selected to publish/delete/etc
* fix categories editing so it had a cancel button and matches the rest of the cms in editing experience