### PR TITLE
Form email html generation

### DIFF
--- a/admin/controllers/forms/views/submissions/model.php
+++ b/admin/controllers/forms/views/submissions/model.php
@@ -10,8 +10,24 @@ $paginationSize = Configuration::get_configuration_value ('general_options', 'pa
 
 $curPage = Input::getvar('page','INT','1');
 
+$formSelectOptions = DB::fetchall("SELECT DISTINCT form_id AS value, form_path FROM form_submissions");
+$formSelectOptions = array_map(function($input) {
+    $option = (object) [
+        "value"=>$input->value,
+        "text"=>$input->value,
+    ];
+
+    $json = json_decode(file_get_contents(CMSPATH . $input->form_path));
+    if(isset($json->display_name)) {
+        $option->text = $json->display_name;
+    }
+
+    return $option;
+    
+}, $formSelectOptions);
+
 $searchFieldsObject = json_decode(file_get_contents(CMSPATH . "/admin/controllers/forms/views/submissions/search_fields.json"));
-$searchFieldsObject->fields[0]->select_options = DB::fetchall("SELECT DISTINCT form_id AS text, form_id as value FROM form_submissions");
+$searchFieldsObject->fields[0]->select_options = $formSelectOptions;
 if(!$_GET["form"] && $searchFieldsObject->fields[0]->select_options[0]) {
     $searchFieldsObject->fields[0]->default = $searchFieldsObject->fields[0]->select_options[0]->value;
 }


### PR DESCRIPTION
adds two methods to the form class
* one for creating the basic html wrapper around body content (so you can make your own email for whatever)
* generate a submission email from form fields

adds a new variable to the form class called display name, falls back to id for forms that dont have it. its purpose is to be a nice user readable name. additionally have added code to the admin form submission viewer to use this name in the dropdown if present.

ignore the broken image
![image](https://github.com/user-attachments/assets/2ac657c3-1bd2-4991-81b5-092c64cbd13e)

some sample code
```php
if($form->is_submitted()) {
    $form->set_from_submit();
    $form->save_to_db();

    $mail = new Mail();
    $mail->addAddress("testemail@wouldntyouliketoknow.com","amazing tester");
    $mail->subject = "get spammed";
    $mail->html = $form->create_email_html();
    $mail->send(); 
}
```