### PR TITLE
input field css updates

### DIFF
--- a/admin/templates/clean/css/darkmode.css
+++ b/admin/templates/clean/css/darkmode.css
@@ -37,4 +37,7 @@
             }
         }
     }
+    input[type="date"]::-webkit-calendar-picker-indicator {
+        filter: invert(1);
+    }
 }

--- a/admin/templates/clean/css/darkmode.css
+++ b/admin/templates/clean/css/darkmode.css
@@ -37,7 +37,12 @@
             }
         }
     }
-    input[type="date"]::-webkit-calendar-picker-indicator {
+    input[type="date"]::-webkit-calendar-picker-indicator,
+    input[type="datetime-local"]::-webkit-calendar-picker-indicator,
+    input[type="time"]::-webkit-calendar-picker-indicator,
+    input[type="month"]::-webkit-calendar-picker-indicator,
+    input[type="week"]::-webkit-calendar-picker-indicator
+    {
         filter: invert(1);
     }
     .ss-main .ss-multi-selected, .ss-single-selected {

--- a/admin/templates/clean/css/darkmode.css
+++ b/admin/templates/clean/css/darkmode.css
@@ -44,6 +44,5 @@
     }
     .ss-main .ss-multi-selected, .ss-single-selected {
         border: 1px solid hsl(221, 14%,calc(24% + 0%)) !important;
-        /* border: var(--bulma-border-l) !important; */
     }
 }

--- a/admin/templates/clean/css/darkmode.css
+++ b/admin/templates/clean/css/darkmode.css
@@ -40,4 +40,7 @@
     input[type="date"]::-webkit-calendar-picker-indicator {
         filter: invert(1);
     }
+    .ss-main .ss-multi-selected, .ss-single-selected {
+        border: 1px solid hsl(221, 14%,calc(24% + 0%)) !important;
+    }
 }

--- a/admin/templates/clean/css/darkmode.css
+++ b/admin/templates/clean/css/darkmode.css
@@ -37,15 +37,13 @@
             }
         }
     }
-    input[type="date"]::-webkit-calendar-picker-indicator,
-    input[type="datetime-local"]::-webkit-calendar-picker-indicator,
-    input[type="time"]::-webkit-calendar-picker-indicator,
-    input[type="month"]::-webkit-calendar-picker-indicator,
-    input[type="week"]::-webkit-calendar-picker-indicator
-    {
-        filter: invert(1);
+    input[type="date"], input[type="datetime-local"], input[type="time"], input[type="month"], input[type="week"] {
+        &::-webkit-calendar-picker-indicator {
+          filter: invert(1);
+        }
     }
     .ss-main .ss-multi-selected, .ss-single-selected {
         border: 1px solid hsl(221, 14%,calc(24% + 0%)) !important;
+        /* border: var(--bulma-border-l) !important; */
     }
 }

--- a/admin/templates/clean/css/dashboard.css
+++ b/admin/templates/clean/css/dashboard.css
@@ -69,6 +69,9 @@ input:invalid {
 input:required:valid {
   border: 1px solid green;
 }
+input[type="date"] {
+  display: block;
+}
 
 .menu_node {
     /* margin: 1rem; */

--- a/admin/templates/clean/css/dashboard.css
+++ b/admin/templates/clean/css/dashboard.css
@@ -69,7 +69,7 @@ input:invalid {
 input:required:valid {
   border: 1px solid green;
 }
-input[type="date"] {
+input[type="date"], input[type="datetime-local"], input[type="time"], input[type="month"], input[type="week"] {
   display: block;
 }
 


### PR DESCRIPTION
- updated calendar selector icon to be visible in dark mode and adjusted it to be at the end of the input box (for `date`, `time`, `datetime-local`, `week`, and `month`)
- made the slim selector border consistent with the other input borders