### PR TITLE
feat: convert core cms files to use exceptions rather than errors and add exceptions handler

### DIFF
--- a/core/category.php
+++ b/core/category.php
@@ -52,13 +52,7 @@ class Category {
 				// try and get type id
 				$content_type = Content::get_content_type_id($content_type);
 				if (!$content_type) {
-					if (Config::debug()) {
-						CMS::pprint_r("Unable to determine content type when retrieving count");
-						CMS::pprint_r(debug_backtrace());
-						die();
-					} else {
-						CMS::Instance()->show_error('Unable to determine content type when retrieving count');
-					}
+					throw new Exception("Unable to determine content type when retrieving count");
 				}
 			}
 			return DB::fetch('select count(*) as c from categories where (title like ?) and state>0 and content_type=?',[$like,$content_type])->c;
@@ -72,13 +66,7 @@ class Category {
 				// try and get type id
 				$content_type = Content::get_content_type_id($content_type);
 				if (!$content_type) {
-					if (Config::debug()) {
-						CMS::pprint_r("Unable to determine content type when retrieving count");
-						CMS::pprint_r(debug_backtrace());
-						die();
-					} else {
-						CMS::Instance()->show_error('Unable to determine content type when retrieving count');
-					}
+					throw new Exception('Unable to determine content type when retrieving count');
 				}
 			}
 			return DB::fetch('select count(*) as c from categories where state>0 and content_type=?',[$content_type])->c;

--- a/core/content.php
+++ b/core/content.php
@@ -24,13 +24,7 @@ class Content {
 
 	public static function get_table_name_for_content_type($type_id) {
 		if (!is_numeric($type_id)) {
-			if (Config::debug()) {
-				CMS::pprint_r("Unable to determine table name for non-numeric content type");
-				CMS::pprint_r(debug_backtrace());
-				die();
-			} else {
-				CMS::Instance()->show_error('Unable to determine table name for non-numeric content type');
-			}
+			throw new Exception('Unable to determine table name for non-numeric content type');
 		}
 		else {
 			$location = Content::get_content_location($type_id);
@@ -40,13 +34,7 @@ class Content {
 				return $table_name;
 			}
 			else {
-				if (Config::debug()) {
-					CMS::pprint_r('Unable to determine table name for content id ' . $type_id);
-					CMS::pprint_r(debug_backtrace());
-					die();
-				} else {
-					CMS::Instance()->show_error('Unable to determine table name for content id ' . $type_id);
-				}
+				throw new Exception('Unable to determine table name for content id ' . $type_id);
 			}
 		}
 	}
@@ -110,12 +98,9 @@ class Content {
 		if (!$this->table_name) {
 			if(Config::debug()) {
 				CMS::pprint_r ($this);
-				CMS::pprint_r(debug_backtrace());
-				die();
-			} else {
-				CMS::show_error('Unknown table name', 500);
-				die();
 			}
+			
+			throw new Exception('Unknown table name', 500);
 		}
 		$query = "select `{$field_name}` as v from `{$this->table_name}` where id=?";
 		$value = DB::fetch($query, [$this->id])->v; // todo: can we make col name param?

--- a/core/content_search.php
+++ b/core/content_search.php
@@ -63,13 +63,7 @@ class Content_Search {
 			if (!is_numeric($this->type_filter)) {
 				$this->type_filter= Content::get_content_type_id($this->type_filter);
 				if (!$this->type_filter) {
-					if (Config::debug()) {
-						CMS::pprint_r('Unable to determine content type');
-						CMS::pprint_r(debug_backtrace());
-						die();
-					} else {
-						CMS::Instance()->show_error('Unable to determine content type');
-					}
+					throw new Exception('Unable to determine content type');
 				}
 			}
 			$location = Content::get_content_location($this->type_filter);
@@ -122,13 +116,7 @@ class Content_Search {
 			}
 		} 
 		else {
-			if (Config::debug()) {
-				CMS::pprint_r('No content type filter provided for content search');
-				CMS::pprint_r(debug_backtrace());
-				die();
-			} else {
-				CMS::Instance()->show_error('No content type filter provided for content search');
-			}
+			throw new Exception('No content type filter provided for content search');
 		}
 		$query = "select";
 		$select = " c.id, c.state, c.content_type, c.title, c.alias, c.ordering, c.start, c.end, c.created_by, c.updated_by, c.note, c.category, cat.title  as catname";

--- a/core/controller.php
+++ b/core/controller.php
@@ -37,7 +37,7 @@ class Controller {
 				}
 			}
 			else {
-				CMS::Instance()->show_error("View folder {$this->view} doesn't exist for controller at " . $this->path, 500);
+				throw new Exception("View folder {$this->view} doesn't exist for controller at " . $this->path);
 			}
 		}
 	}

--- a/core/db.php
+++ b/core/db.php
@@ -2,48 +2,12 @@
 defined('CMSPATH') or die; // prevent unauthorized access
 
 class DB {
-	public $pdo;
-
-	public function __construct() {
-		$dsn = "mysql:host=" . Config::dbhost() . ";dbname=" . Config::dbname() . ";charset=" . Config::dbchar();
-		$options = [
-			PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
-			PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_OBJ,
-			PDO::ATTR_EMULATE_PREPARES   => false,
-		];
-		try {
-			$this->pdo = new PDO($dsn, Config::dbuser(), Config::dbpass(), $options);
-		} catch (\PDOException $e) {
-			if (Config::debug()) {
-				throw new \PDOException($e->getMessage(), (int)$e->getCode());
-			}
-			else {
-				CMS::show_error("Failed to connect to database: " . Config::dbname());
-			}
-		}
-	}	
-
 	public static function exec($query, $paramsarray=[]) {
 		if (!is_array($paramsarray)) {
 			$paramsarray = [$paramsarray];
 		}
-		try {
-			$stmt = CMS::Instance()->pdo->prepare($query);
-			$success = $stmt->execute($paramsarray);
-		}
-		catch (\PDOException $e) {
-			if (Config::debug()) {
-				CMS::pprint_r("Failed to create PDO query statement: " . $e->getMessage());
-				CMS::pprint_r(debug_backtrace());
-				die();
-			}
-			else {
-				//CMS::pprint_r(debug_backtrace()); die();
-				CMS::show_error("Failed to create PDO query statement: " . $e->getMessage());
-				//CMS::show_error("Database query error - turn on debug for more information.");
-			}
-		}
-		return $success;
+		$stmt = CMS::Instance()->pdo->prepare($query);
+		return $stmt->execute($paramsarray);
 	}
 
 	public static function get_last_insert_id() {
@@ -54,23 +18,9 @@ class DB {
 		if (!is_array($paramsarray)) {
 			$paramsarray = [$paramsarray];
 		}
-		try {
-			$stmt = CMS::Instance()->pdo->prepare($query);
-			$stmt->execute($paramsarray);
-			$result = $stmt->fetchAll($options["mode"] ?? PDO::FETCH_OBJ);
-		}
-		catch (\PDOException $e) {
-			if (Config::debug()) {
-				CMS::pprint_r("Failed to create PDO query statement: " . $e->getMessage());
-				CMS::pprint_r(debug_backtrace());
-				die();
-			}
-			else {
-				//CMS::pprint_r(debug_backtrace()); die();
-				CMS::show_error("Database query error - turn on debug for more information.");
-			}
-		}
-		return $result;
+		$stmt = CMS::Instance()->pdo->prepare($query);
+		$stmt->execute($paramsarray);
+		return $stmt->fetchAll($options["mode"] ?? PDO::FETCH_OBJ);
 	}
 
 	public static function fetchallcolumn($query, $paramsarray=[]) {
@@ -81,22 +31,8 @@ class DB {
 		if (!is_array($paramsarray)) {
 			$paramsarray = [$paramsarray];
 		}
-		try {
-			$stmt = CMS::Instance()->pdo->prepare($query);
-			$stmt->execute($paramsarray);
-			$result = $stmt->fetch($options["mode"] ?? PDO::FETCH_OBJ);
-		}
-		catch (\PDOException $e) {
-			if (Config::debug()) {
-				CMS::pprint_r("Failed to create PDO query statement: " . $e->getMessage());
-				CMS::pprint_r(debug_backtrace());
-				die();
-			}
-			else {
-				//CMS::pprint_r(debug_backtrace()); die();
-				CMS::show_error("Database query error - turn on debug for more information.");
-			}
-		}
-		return $result;
+		$stmt = CMS::Instance()->pdo->prepare($query);
+		$stmt->execute($paramsarray);
+		return $stmt->fetch($options["mode"] ?? PDO::FETCH_OBJ);
 	}
 }

--- a/core/form.php
+++ b/core/form.php
@@ -204,7 +204,7 @@ class Form implements JsonSerializable {
 	public function save_to_db() {
 		//if the form was loaded from an object and the path not set afterwords.....
 		if(gettype($this->form_path)!="string") {
-			CMS::show_error("Failed to save form submission, bad form path!", 500);
+			throw new Exception("Failed to save form submission, bad form path!");
 		}
 
 		DB::exec(

--- a/core/image.php
+++ b/core/image.php
@@ -17,13 +17,7 @@ class Image {
     
     public function __construct($id) {
         if (!is_numeric($id)) {
-            if (Config::debug()) {
-                CMS::pprint_r("Cannot create image object from non-numerical id");
-                CMS::pprint_r(debug_backtrace());
-                die();
-            } else {
-                CMS::Instance()->show_error('Cannot create image object from non-numerical id');
-            }
+            throw new Exception('Cannot create image object from non-numerical id');
         }
         else {
             $this->id = $id;

--- a/core/json.php
+++ b/core/json.php
@@ -8,32 +8,30 @@ class JSON {
 				$json = file_get_contents($file);
 				$obj = json_decode($json);
 				if (!$obj) {
+					$messsage = "JSON decode error";
 					if (Config::debug()) {
-						CMS::pprint_r('Error decoding JSON in file &ldquo;' . $file . '&rdquo;');
-						CMS::pprint_r(debug_backtrace());
-						die();
-					} else {
-						CMS::Instance()->show_error('JSON decode error');
+						$mssage = 'Error decoding JSON in file &ldquo;' . $file . '&rdquo;';
 					}
+
+					throw new Exception($message);
 				}
 				else {
 					return $obj;
 				}
 			}
+			$message = "JSON decode error";
 			if (Config::debug()) {
-				CMS::pprint_r('Cannot read JSON file &ldquo;' . $file . '&rdquo;');
-				CMS::pprint_r(debug_backtrace());
-				die();
-			} else {
-				CMS::Instance()->show_error('JSON decode error');
+				$message = 'Cannot read JSON file &ldquo;' . $file . '&rdquo;';
 			}
+
+			throw new Exception($message);
 		}
+
+		$message = "JSON decode error";
 		if (Config::debug()) {
-			CMS::pprint_r('Cannot find JSON file &ldquo;' . $file . '&rdquo;');
-			CMS::pprint_r(debug_backtrace());
-			die();
-		} else {
-			CMS::Instance()->show_error('JSON decode error');
+			$message = 'Cannot find JSON file &ldquo;' . $file . '&rdquo;';
 		}
+		
+		throw new Exception($message);
 	}
 }

--- a/core/json.php
+++ b/core/json.php
@@ -8,9 +8,9 @@ class JSON {
 				$json = file_get_contents($file);
 				$obj = json_decode($json);
 				if (!$obj) {
-					$messsage = "JSON decode error";
+					$message = "JSON decode error";
 					if (Config::debug()) {
-						$mssage = 'Error decoding JSON in file &ldquo;' . $file . '&rdquo;';
+						$message = 'Error decoding JSON in file &ldquo;' . $file . '&rdquo;';
 					}
 
 					throw new Exception($message);

--- a/core/mail.php
+++ b/core/mail.php
@@ -55,7 +55,7 @@ class Mail {
 	public function send() {
 
 		if (!$this->to || !$this->subject || !$this->html) {
-			CMS::show_error('No to, subject, or content provided to send email');
+			throw new Exception('No to, subject, or content provided to send email');
 		}
 
 		$smtp_name = Configuration::get_configuration_value ('general_options', 'smtp_name');

--- a/core/messages.php
+++ b/core/messages.php
@@ -34,7 +34,9 @@ class Messages {
 		} 
 		
 		// Make sure it's a valid message type
-		if( !in_array($type, $this->msgTypes) ) die('"' . strip_tags($type) . '" is not a valid message type!' );
+		if( !in_array($type, $this->msgTypes) ) {
+			throw new Exception('"' . strip_tags($type) . '" is not a valid message type!' );
+		}
 		
 		// If the session array doesn't exist, create it
 		//if( !array_key_exists( $type, $_SESSION['flash_messages'] ) ) $_SESSION['flash_messages'][$type] = [];

--- a/core/plugin.php
+++ b/core/plugin.php
@@ -37,15 +37,15 @@ class Plugin {
     } 
     
     public function init() {
-        CMS::show_error('Default plugin init called - should never happen');
+        throw new Exception('Default plugin init called - should never happen');
     }
 
     public function execute_action(...$args) {
-        CMS::show_error('Default plugin execute_action called - should never happen');
+        throw new Exception('Default plugin execute_action called - should never happen');
     }
 
     public function execute_filter($data, ...$args) {
-        CMS::show_error('Default plugin execute_filter called - should never happen');
+        throw new Exception('Default plugin execute_filter called - should never happen');
     }
 
 	public static function get_plugin_title ($id) {
@@ -93,7 +93,7 @@ class Plugin {
 			}
         }
         else {
-            CMS::show_error('Unknown plugin');
+            throw new Exception('Unknown plugin');
         }
 	}
 }

--- a/core/template.php
+++ b/core/template.php
@@ -56,7 +56,7 @@ class Template {
 			return new Template($result->id);
 		}
 		else {
-			CMS::show_error('Failed to determine default template');
+			throw new Exception('Failed to determine default template');
 		}
 	}
 

--- a/core/user.php
+++ b/core/user.php
@@ -40,13 +40,7 @@ class User {
 			return $id;
 		}
 		else {
-			if (Config::debug()) {
-				CMS::pprint_r('Unable to create new user');
-				CMS::pprint_r(debug_backtrace());
-				die();
-			} else {
-				CMS::Instance()->show_error('Unable to create new user');
-			}
+			throw new Exception('Unable to create new user');
 		}
 	}
 	


### PR DESCRIPTION
does what it says on the tin

if debug is of, shows cms error to the user, if its on, shows this:
![image](https://github.com/user-attachments/assets/1ad18ac0-42b8-4c13-a8ce-66ea70e7fb36)

see https://www.php.net/manual/en/function.set-exception-handler.php regard exception handling. the tldr is this allows us to try/catch cms methods (handler doesnt fire), and if we dont have a try/catch the handler will kick in display the exception according to the configs debug flag
