### PR TITLE
bug: strip classes from pasted html in editor

### DIFF
--- a/core/fields/Field_Rich.php
+++ b/core/fields/Field_Rich.php
@@ -446,6 +446,12 @@ class Field_Rich extends Field {
 						},
 					};
 
+					function stripClassAttributes(html) {
+						const doc = new DOMParser().parseFromString(html, 'text/html')
+						doc.querySelectorAll('[class]').forEach(el => el.removeAttribute('class'))
+						return doc.body.innerHTML
+					}
+
 					const editorInstance = new Editor({
 						element: editorElement,
 						extensions: [
@@ -538,6 +544,9 @@ class Field_Rich extends Field {
 								},
 							}),
 						],
+						editorProps: {
+							transformPastedHTML: html => stripClassAttributes(html),
+						},
 						content: `<?php echo $this->default; ?>`,
 					});
 


### PR DESCRIPTION
does what it says on the tin. due to me adding an extension that implements class support so the attribute existed to fill in