### PR TITLE
figures support in the editor

### DIFF
--- a/src/Fields/Rich/Rich.php
+++ b/src/Fields/Rich/Rich.php
@@ -135,6 +135,7 @@ class Rich extends Field {
 					import FileHandler from 'https://esm.sh/@tiptap/extension-file-handler@3.2.1'
 					import {getValidImageTypes, doUpload} from "/js/image_uploading.js?v=2"
 					import { findChildrenInRange, mergeAttributes, Node, nodeInputRule, Tracker } from 'https://esm.sh/@tiptap/core@3.2.1'
+					import { Plugin, PluginKey } from 'https://esm.sh/@tiptap/pm@3.2.1/state'
 					
 					const editorWrapperRoot = document.querySelector(`.editor_root_node:has([<?php echo $this->getRenderedName(); ?>][data-repeatableindex="{{replace_with_index}}"])`);
 					const editorElement = editorWrapperRoot.querySelector('.gui_editor');
@@ -170,7 +171,10 @@ class Rich extends Field {
 						},
 					};
 
-					<?php echo file_get_contents(__DIR__ . "/figure.js"); ?>
+					<?php
+						echo file_get_contents(__DIR__ . "/figure.js");
+						echo file_get_contents(__DIR__ . "/figcaption.js");
+					?>
 
 					function stripClassAttributes(html) {
 						const doc = new DOMParser().parseFromString(html, 'text/html');
@@ -317,6 +321,7 @@ class Rich extends Field {
 								},
 							}),
 							Figure,
+							Figcaption,
 						],
 						editorProps: {
 							transformPastedHTML: html => stripClassAttributes(html),

--- a/src/Fields/Rich/Rich.php
+++ b/src/Fields/Rich/Rich.php
@@ -133,7 +133,8 @@ class Rich extends Field {
 					import BubbleMenu from 'https://esm.sh/@tiptap/extension-bubble-menu@3.2.1'
 					import { Details, DetailsContent, DetailsSummary } from 'https://esm.sh/@tiptap/extension-details@3.2.1'
 					import FileHandler from 'https://esm.sh/@tiptap/extension-file-handler@3.2.1'
-					import {getValidImageTypes, doUpload} from "/js/image_uploading.js?v=2";
+					import {getValidImageTypes, doUpload} from "/js/image_uploading.js?v=2"
+					import { findChildrenInRange, mergeAttributes, Node, nodeInputRule, Tracker } from 'https://esm.sh/@tiptap/core@3.2.1'
 					
 					const editorWrapperRoot = document.querySelector(`.editor_root_node:has([<?php echo $this->getRenderedName(); ?>][data-repeatableindex="{{replace_with_index}}"])`);
 					const editorElement = editorWrapperRoot.querySelector('.gui_editor');
@@ -168,6 +169,8 @@ class Rich extends Field {
 							}
 						},
 					};
+
+					<?php echo file_get_contents(__DIR__ . "/figure.js"); ?>
 
 					function stripClassAttributes(html) {
 						const doc = new DOMParser().parseFromString(html, 'text/html');
@@ -313,6 +316,7 @@ class Rich extends Field {
 									console.log("file dropped");
 								},
 							}),
+							Figure,
 						],
 						editorProps: {
 							transformPastedHTML: html => stripClassAttributes(html),

--- a/src/Fields/Rich/Rich.php
+++ b/src/Fields/Rich/Rich.php
@@ -276,7 +276,8 @@ class Rich extends Field {
 								pluginKey: "imageBubbleBar",
 								element: editorWrapperRoot.querySelector('.image-bubble-bar'),
 								shouldShow: ({ editor, view, state, oldState, from, to }) => {
-									return editor.isActive('image');
+									//dont show on images inside a figure
+									return editor.isActive('image') && editor.state.selection.$from.parent.type.name != "figure";
 								},
 							}),
 							Details.configure({

--- a/src/Fields/Rich/Rich.php
+++ b/src/Fields/Rich/Rich.php
@@ -42,6 +42,17 @@ class Rich extends Field {
 							<i class='fa fa-align-right'></i>
 							<span>Float Right</span>
 						</div>
+						<hr>
+						<div>
+							<i class='fa fa-image'></i>
+							<span>To Figure</span>
+						</div>
+					</div>
+					<div class="image-figure-unlink-bar">
+						<div>
+							<i class='fa fa-image'></i>
+							<span>UnJoin Figure</span>
+						</div>
 					</div>
 				</div>
 				<div class="gui_editor_control_bar">
@@ -278,6 +289,14 @@ class Rich extends Field {
 								shouldShow: ({ editor, view, state, oldState, from, to }) => {
 									//dont show on images inside a figure
 									return editor.isActive('image') && editor.state.selection.$from.parent.type.name != "figure";
+								},
+							}),
+							BubbleMenu.configure({
+								pluginKey: "imageFigureUnlinkBubbleBar",
+								element: editorWrapperRoot.querySelector(".image-figure-unlink-bar"),
+								shouldShow: ({ editor, view, state, oldState, from, to }) => {
+									//dont show on images inside a figure
+									return editor.isActive('image') && editor.state.selection.$from.parent.type.name == "figure";
 								},
 							}),
 							Details.configure({
@@ -941,6 +960,10 @@ class Rich extends Field {
 							classes = classes.replace("pull-left", "");
 							classes = classes.replace("pull-right", "");
 							editorInstance.chain().updateAttributes('image', { class : `${classes}`}).run();
+						} else if(e.target.matches(".image-bubble-bar div:has(.fa.fa-image)")) {
+							editorInstance.chain().focus().imageToFigure().run()
+						} else if(e.target.matches(".image-figure-unlink-bar div:has(.fa.fa-image)")) {
+							editorInstance.chain().focus().figureToImage().run()
 						}
 					});
 				</script>

--- a/src/Fields/Rich/figcaption.js
+++ b/src/Fields/Rich/figcaption.js
@@ -1,0 +1,101 @@
+
+// biome-ignore lint/correctness/noUnusedVariables: required in
+const Figcaption = Node.create({
+  name: 'figcaption',
+
+  content: 'paragraph+',
+  group: 'block',
+  selectable: false,
+  draggable: false,
+
+  parseHTML() {
+    return [
+      {
+        tag: 'figcaption',
+      },
+    ]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['figcaption', mergeAttributes(HTMLAttributes), 0]
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey('figcaption-enter'),
+        props: {
+          handleKeyDown(view, event) {
+            if (event.key === 'Enter') {
+              const { state, dispatch } = view
+              const { selection } = state
+              const $pos = selection.$from
+              let debug = ''
+              // Find the parent figure node
+              let figureDepth = null
+              for (let d = $pos.depth; d > 0; d--) {
+                if ($pos.node(d).type.name === 'figure') {
+                  figureDepth = d
+                  break
+                }
+              }
+              const parentIsFigcaption = $pos.node($pos.depth - 1).type.name === 'figcaption'
+              debug += `figureDepth: ${figureDepth}, currentNode: ${$pos.node($pos.depth).type.name}, parentIsFigcaption: ${parentIsFigcaption}\n`
+              if (figureDepth !== null && parentIsFigcaption) {
+                // Only trigger if at end of last paragraph in figcaption
+                const figcaptionNode = $pos.node($pos.depth - 1)
+                const isLastParagraph = $pos.index($pos.depth - 1) === figcaptionNode.childCount - 1
+                const atEnd = $pos.parentOffset === $pos.parent.content.size
+                debug += `isLastParagraph: ${isLastParagraph}, atEnd: ${atEnd}\n`
+                // Only break out if current paragraph is empty
+                const currentParagraphIsEmpty = $pos.parent.textContent === ''
+                debug += `currentParagraphIsEmpty: ${currentParagraphIsEmpty}\n`
+                if (isLastParagraph && atEnd && currentParagraphIsEmpty) {
+                  const figurePos = $pos.after(figureDepth)
+                  debug += `figurePos: ${figurePos}\n`
+                  // Find the empty paragraph position and size before any changes
+                  const figcaptionNode = $pos.node($pos.depth - 1)
+                  const paraIndex = $pos.index($pos.depth - 1)
+                  const paraNode = figcaptionNode.child(paraIndex)
+                  const paraPos = $pos.start($pos.depth - 1)
+                  let tr = state.tr
+                  // Always check for and delete any empty paragraph at the end of figcaption
+                  // Use the already declared figcaptionNode
+                  let lastParaIndex = figcaptionNode.childCount - 1
+                  let lastParaNode = figcaptionNode.child(lastParaIndex)
+                  let lastParaPos = $pos.start($pos.depth - 1)
+                  for (let i = 0; i < lastParaIndex; i++) {
+                    lastParaPos += figcaptionNode.child(i).nodeSize
+                  }
+                  if (lastParaNode && lastParaNode.type.name === 'paragraph' && lastParaNode.textContent === '') {
+                    tr = tr.delete(lastParaPos, lastParaPos + lastParaNode.nodeSize)
+                  }
+                  // Recalculate figure position after delete
+                  const resolved = tr.doc.resolve(lastParaPos)
+                  let newFigureDepth = null
+                  for (let d = resolved.depth; d > 0; d--) {
+                    if (resolved.node(d).type.name === 'figure') {
+                      newFigureDepth = d
+                      break
+                    }
+                  }
+                  if (newFigureDepth !== null) {
+                    const newFigurePos = resolved.after(newFigureDepth)
+                    tr = tr.insert(newFigurePos, tr.doc.type.schema.nodes.paragraph.create())
+                    tr.setSelection(state.selection.constructor.near(tr.doc.resolve(newFigurePos + 1)))
+                  }
+                  dispatch(tr)
+                  event.preventDefault()
+                  console.log('[figcaption enter handler]', debug)
+                  return true
+                }
+              }
+              console.log('[figcaption enter handler - not triggered]', debug)
+            }
+            return false
+          },
+        },
+      }),
+    ]
+  },
+})

--- a/src/Fields/Rich/figure.js
+++ b/src/Fields/Rich/figure.js
@@ -12,7 +12,7 @@ const Figure = Node.create({
 
   group: 'block',
 
-  content: 'inline*',
+  content: 'image figcaption',
 
   draggable: true,
 
@@ -41,17 +41,16 @@ const Figure = Node.create({
     return [
       {
         tag: 'figure',
-        contentElement: 'figcaption',
       },
     ]
   },
 
+  // biome-ignore lint/correctness/noUnusedFunctionParameters: not touching this
   renderHTML({ HTMLAttributes }) {
     return [
       'figure',
       this.options.HTMLAttributes,
-      ['img', mergeAttributes(HTMLAttributes, { draggable: false, contenteditable: false })],
-      ['figcaption', 0],
+      0,
     ]
   },
 
@@ -65,7 +64,12 @@ const Figure = Node.create({
               .insertContent({
                 type: this.name,
                 attrs,
-                content: caption ? [{ type: 'text', text: caption }] : [],
+                content: [
+                  { type: 'image', attrs },
+                  caption
+                    ? { type: 'figcaption', content: caption }
+                    : { type: 'figcaption' },
+                ],
               })
               // set cursor at end of caption field
               .command(({ tr, commands }) => {

--- a/src/Fields/Rich/figure.js
+++ b/src/Fields/Rich/figure.js
@@ -1,0 +1,164 @@
+const inputRegex = /!\[(.+|:?)]\((\S+)(?:(?:\s+)["'](\S+)["'])?\)/
+
+// biome-ignore lint/correctness/noUnusedVariables: required in
+const Figure = Node.create({
+  name: 'figure',
+
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+    }
+  },
+
+  group: 'block',
+
+  content: 'inline*',
+
+  draggable: true,
+
+  isolating: true,
+
+  addAttributes() {
+    return {
+      src: {
+        default: null,
+        parseHTML: element => element.querySelector('img')?.getAttribute('src'),
+      },
+
+      alt: {
+        default: null,
+        parseHTML: element => element.querySelector('img')?.getAttribute('alt'),
+      },
+
+      title: {
+        default: null,
+        parseHTML: element => element.querySelector('img')?.getAttribute('title'),
+      },
+    }
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'figure',
+        contentElement: 'figcaption',
+      },
+    ]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      'figure',
+      this.options.HTMLAttributes,
+      ['img', mergeAttributes(HTMLAttributes, { draggable: false, contenteditable: false })],
+      ['figcaption', 0],
+    ]
+  },
+
+  addCommands() {
+    return {
+      setFigure:
+        ({ caption, ...attrs }) =>
+        ({ chain }) => {
+          return (
+            chain()
+              .insertContent({
+                type: this.name,
+                attrs,
+                content: caption ? [{ type: 'text', text: caption }] : [],
+              })
+              // set cursor at end of caption field
+              .command(({ tr, commands }) => {
+                const { doc, selection } = tr
+                const position = doc.resolve(selection.to - 2).end()
+
+                return commands.setTextSelection(position)
+              })
+              .run()
+          )
+        },
+
+      imageToFigure:
+        () =>
+        ({ tr, commands }) => {
+          const { doc, selection } = tr
+          const { from, to } = selection
+          const images = findChildrenInRange(doc, { from, to }, node => node.type.name === 'image')
+
+          if (!images.length) {
+            return false
+          }
+
+          const tracker = new Tracker(tr)
+
+          return commands.forEach(images, ({ node, pos }) => {
+            const mapResult = tracker.map(pos)
+
+            if (mapResult.deleted) {
+              return false
+            }
+
+            const range = {
+              from: mapResult.position,
+              to: mapResult.position + node.nodeSize,
+            }
+
+            return commands.insertContentAt(range, {
+              type: this.name,
+              attrs: {
+                src: node.attrs.src,
+              },
+            })
+          })
+        },
+
+      figureToImage:
+        () =>
+        ({ tr, commands }) => {
+          const { doc, selection } = tr
+          const { from, to } = selection
+          const figures = findChildrenInRange(doc, { from, to }, node => node.type.name === this.name)
+
+          if (!figures.length) {
+            return false
+          }
+
+          const tracker = new Tracker(tr)
+
+          return commands.forEach(figures, ({ node, pos }) => {
+            const mapResult = tracker.map(pos)
+
+            if (mapResult.deleted) {
+              return false
+            }
+
+            const range = {
+              from: mapResult.position,
+              to: mapResult.position + node.nodeSize,
+            }
+
+            return commands.insertContentAt(range, {
+              type: 'image',
+              attrs: {
+                src: node.attrs.src,
+              },
+            })
+          })
+        },
+    }
+  },
+
+  addInputRules() {
+    return [
+      nodeInputRule({
+        find: inputRegex,
+        type: this.type,
+        getAttributes: match => {
+          const [, src, alt, title] = match
+
+          return { src, alt, title }
+        },
+      }),
+    ]
+  },
+})

--- a/src/Fields/Rich/figure.js
+++ b/src/Fields/Rich/figure.js
@@ -107,11 +107,18 @@ const Figure = Node.create({
               to: mapResult.position + node.nodeSize,
             }
 
+            // Insert a figure node with image and figcaption children (figcaption must have non-empty text content)
             return commands.insertContentAt(range, {
               type: this.name,
               attrs: {
                 src: node.attrs.src,
+                alt: node.attrs.alt,
+                title: node.attrs.title,
               },
+              content: [
+                { type: 'image', attrs: node.attrs },
+                { type: 'figcaption', content: [ { type: 'paragraph', text: '' } ] },
+              ],
             })
           })
         },

--- a/src/Fields/Rich/style.css
+++ b/src/Fields/Rich/style.css
@@ -6,7 +6,7 @@
     border: 1px solid var(--border-color);
     position: relative;
 
-    .link-bubble-bar, .image-bubble-bar {
+    .link-bubble-bar, .image-bubble-bar, .image-figure-unlink-bar {
         background-color: var(--background-color);
         border-radius: 0.5rem;
         border: 1px solid var(--border-color);

--- a/src/Fields/Rich/style.css
+++ b/src/Fields/Rich/style.css
@@ -344,6 +344,34 @@
                     margin: 0.5rem 0;
                 }
             }
+
+            figure {
+                --outline-color: color-mix(in srgb, var(--border-color) 100%, white 50%);
+
+                align-items: start;
+                border: 2px solid var(--outline-color);
+                border-radius: 0.5rem;
+                display: flex;
+                flex-direction: column;
+                gap: 0.5rem;
+                margin: 1rem 0;
+                padding: 0.5rem;
+                width: fit-content;
+
+                > *:not(figcaption) {
+                    margin: 0;
+                    max-width: 100%;
+                }
+
+                figcaption {
+                    border-radius: 0.5rem;
+                    border: 2px dashed var(--outline-color);
+                    padding: 0.5rem;
+                    text-align: center;
+                    width: 100%;
+                    contain: inline-size;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
does what it says on the tin

disclaimer: played a bit with vibe coding on the ability for figcaption to have enter out of figure on second enter of a blank paragraph to follow details, quote, etc elements - yes the code for it is terrible. it does work. yes the schema and state logic keeps is somewhat in bounds

i do hope that tiptap one day adds a extension themselves for figures, however the current experiments havent been updated in like 2-4 years