### PR TITLE
chore: add support back? for string content types in tag fields

### DIFF
--- a/src/Fields/TagSingle/TagSingle.php
+++ b/src/Fields/TagSingle/TagSingle.php
@@ -41,9 +41,12 @@ class TagSingle extends Select {
 		$this->content_type = $config->content_type ?? false;
 
 		if ($this->content_type) {
-			$tags = Content::get_applicable_tags ($this->content_type);
-		}
-		else {
+			if(!is_numeric($this->content_type)) {
+				$this->content_type = Content::get_content_type_id($this->content_type);
+			}
+
+			$tags = Content::get_applicable_tags($this->content_type);
+		} else {
 			$tags = Tag::get_all_tags ();
 		}
 


### PR DESCRIPTION
seems this got removed at some point