### PR TITLE
bug: update default htaccess to only block /vendor from the start of the url to avoid touching other url segments that have vendor in it

### DIFF
--- a/bin/datafiles/.htaccess
+++ b/bin/datafiles/.htaccess
@@ -50,7 +50,7 @@ RewriteRule .* index.php [L]
 # send dev tools related requests to 404 page
 RedirectMatch 404 composer.json
 RedirectMatch 404 composer.lock
-RedirectMatch 404 /vendor
+RedirectMatch 404 ^/vendor(/|$)
 RedirectMatch 404 /tests
 RedirectMatch 404 biome.json
 RedirectMatch 404 cmslog.txt


### PR DESCRIPTION
does what it says on the tin