### PR TITLE
feat: add dynamic form builder

### DIFF
--- a/src/Core/CMS.php
+++ b/src/Core/CMS.php
@@ -349,6 +349,8 @@ final class CMS {
 				CMS::pprint_r("Field class not found: " . $fieldClass); die;
 			}
 		}
+
+		Form::registerFieldAlias("Input", "Text");
 	}
 
 	private function __construct() {

--- a/src/Core/Widget.php
+++ b/src/Core/Widget.php
@@ -30,6 +30,10 @@ class Widget {
 			"path" => __DIR__ . '/../Widgets/Menu',
 			"class" => "HoltBosse\\Alba\\Widgets\\Menu\\Menu",
 		],
+		"FormInstance" => [
+			"path" => __DIR__ . '/../Widgets/FormInstance',
+			"class" => "HoltBosse\\Alba\\Widgets\\FormInstance\\FormInstance",
+		],
 	];
 
     public static function registerWidget(string $widgetName, string $widgetPath, string $widgetClass): bool {

--- a/src/Widgets/FormInstance/FormInstance.php
+++ b/src/Widgets/FormInstance/FormInstance.php
@@ -1,0 +1,62 @@
+<?php
+namespace HoltBosse\Alba\Widgets\FormInstance;
+
+Use HoltBosse\Alba\Core\{Widget, Form, CMS, Mail, Configuration, Page};
+Use \Exception;
+Use HoltBosse\DB\DB;
+
+class FormInstance extends Widget {
+	public function render() {
+		$normalizedOptions = array_combine(array_column($this->options, 'name'), array_column($this->options, 'value'));
+		//echo $normalizedOptions["forminstance"];
+
+        if(!is_numeric($normalizedOptions["forminstance"])) {
+            throw new \Exception("FormInstance widget requires a valid form instance ID as 'forminstance' option.");
+        }
+
+        $formDetails = DB::fetch("SELECT * FROM form_instances WHERE id=? AND state>=0", [$normalizedOptions["forminstance"]]);
+
+        $form = new Form($_ENV["root_path_to_forms"] . "/forms/form_instance_" . $normalizedOptions["forminstance"] . ".json");
+
+        if($form->isSubmitted()) {
+            $form->setFromSubmit();
+
+            if($form->validate()) {
+                $form->saveToDB();
+                
+                if(!empty($formDetails->emails)) {
+                    $mail = new Mail();
+
+                    $emails = explode(",", $formDetails->emails);
+                    foreach($emails as $email) {
+                        $user = DB::fetch("SELECT * FROM users WHERE id=?", [trim($email)]);
+
+                        $mail->addAddress(trim($user->email), $user->username ?? ($formDetails->title . " Recipient"));
+                    }
+
+                    $mail->subject = "New form submission: " . $formDetails->title;
+
+                    $adminLogoId = Configuration::get_configuration_value('general_options','admin_logo');
+                    $logoSrc = "https://" . $_SERVER['SERVER_NAME'] . "/image/" . $adminLogoId;
+
+                    $mail->html = $form->createEmailHtml($logoSrc);
+
+                    $mail->send();
+                }
+
+                $redirectToPage = new Page();
+                $redirectToPage->load_from_id($formDetails->submit_page);
+
+                CMS::Instance()->queue_message('Form submitted successfully','success', $redirectToPage->get_url());
+            } else {
+                CMS::Instance()->queue_message('There were errors with your submission, please correct them and try again.','danger', $_SERVER["HTTP_REFERER"] ?? $_SERVER["REQUEST_URI"]);
+                die; //just in case to stop further processing
+            }
+        } else {
+            echo "<form method='post'>";
+                $form->display();
+                echo "<button type='submit' class='btn btn-primary button is-primary'>Submit</button>";
+            echo "</form>";
+        }
+	}
+}

--- a/src/Widgets/FormInstance/widget_config.json
+++ b/src/Widgets/FormInstance/widget_config.json
@@ -1,0 +1,16 @@
+{
+	"title":"CMS Form",
+	"location":"FormInstance",
+	"id":"widget_form_options",
+	"fields":[
+		{
+			"name":"forminstance",
+			"id":"forminstance",
+			"type":"SqlSelector",
+			"label":"Form",
+			"required":true,
+            "query": "SELECT id as value, title as text FROM `form_instances` WHERE state >= 0 ORDER BY title ASC",
+			"filter":"RAW"
+		}
+	]
+}

--- a/src/admin/controllers/forms/views/action/model.php
+++ b/src/admin/controllers/forms/views/action/model.php
@@ -1,0 +1,96 @@
+<?php
+
+Use HoltBosse\Alba\Core\{CMS, Configuration};
+Use HoltBosse\Form\Input;
+Use HoltBosse\DB\DB;
+
+$table_name = "form_instances";
+$action = CMS::Instance()->uri_segments[2];
+
+if (!$action) {
+	CMS::Instance()->queue_message('Unknown action','danger', $_SERVER['HTTP_REFERER']);
+}
+
+if ($action=='toggle') {
+	$id = Input::getvar('id','ARRAYOFINT');
+	if (!$id) {
+		CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
+	}
+	$result = DB::exec("update `$table_name` SET state = (CASE state WHEN 1 THEN 0 ELSE 1 END) where id=?", [$id[0]]); // id always array even with single id being passed
+	if ($result) {
+		$redirect = DB::fetch("SELECT * FROM `$table_name` WHERE id=?", [$id[0]]);
+		$msg = "Form <a href='" . $_ENV["uripath"] . "/admin/forms/edit/{$id[0]}'>item</a> state toggled";
+		CMS::Instance()->queue_message($msg,'success', $_SERVER['HTTP_REFERER']);
+	}
+	else {
+		CMS::Instance()->queue_message('Failed to toggle state of form','danger', $_SERVER['HTTP_REFERER']);
+	}
+}
+
+if ($action=='togglestate') {
+	$togglestate = Input::getvar('togglestate','ARRAYOFINT');
+	if (!$togglestate) {
+		CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
+	}
+	$result = DB::exec("update `$table_name` SET state = ? where id=?", [$togglestate[1], $togglestate[0]]); //first is id, second is state
+	if ($result) {
+		CMS::Instance()->queue_message('Updated state of form','success', $_SERVER['HTTP_REFERER']);
+	}
+	else {
+		CMS::Instance()->queue_message('Failed to update state of form','danger', $_SERVER['HTTP_REFERER']);
+	}
+}
+
+elseif ($action=='publish') {
+	$id = Input::getvar('id','ARRAYOFINT');
+	if (!$id) {
+		CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
+	}
+	$idlist = implode(',',$id);
+	$result = DB::exec("update `$table_name` SET state = 1 where id in ({$idlist})"); 
+	if ($result) {
+		CMS::Instance()->queue_message('Published form','success', $_SERVER['HTTP_REFERER']);
+	}
+	else {
+		CMS::Instance()->queue_message('Failed to publish form','danger', $_SERVER['HTTP_REFERER']);
+	}
+}
+
+elseif ($action=='unpublish') {
+	$id = Input::getvar('id','ARRAYOFINT');
+	if (!$id) {
+		CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
+	}
+	$idlist = implode(',',$id);
+	$result = DB::exec("update `$table_name` SET state = 0 where id in ({$idlist})"); 
+	if ($result) {
+		CMS::Instance()->queue_message('Unpublished form','success', $_SERVER['HTTP_REFERER']);
+	}
+	else {
+		CMS::Instance()->queue_message('Failed to unpublish form','danger', $_SERVER['HTTP_REFERER']);
+	}
+}
+
+elseif ($action=='delete') {
+	$id = Input::getvar('id','ARRAYOFINT');
+	if (!$id) {
+		CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
+	}
+	$idlist = implode(',',$id);
+	$result = DB::exec("update `$table_name` SET state = -1 where id in ({$idlist})"); 
+	if ($result) {
+		CMS::Instance()->queue_message('Deleted form','success', $_SERVER['HTTP_REFERER']);
+	}
+	else {
+		CMS::Instance()->queue_message('Failed to delete form','danger', $_SERVER['HTTP_REFERER']);
+	}
+}
+
+elseif ($action=='duplicate') {
+	CMS::Instance()->queue_message('Cannot duplicate forms','danger', $_SERVER['HTTP_REFERER']);
+}
+
+else {
+	CMS::Instance()->queue_message('Unknown action','danger', $_SERVER['HTTP_REFERER']);
+}
+

--- a/src/admin/controllers/forms/views/action/view.php
+++ b/src/admin/controllers/forms/views/action/view.php
@@ -1,0 +1,5 @@
+<?php
+
+?>
+
+<h1>Nothing to see here, all action takes place in the model.php</h1>

--- a/src/admin/controllers/forms/views/all/model.php
+++ b/src/admin/controllers/forms/views/all/model.php
@@ -1,0 +1,11 @@
+<?php
+
+Use HoltBosse\Alba\Core\{CMS, Configuration};
+Use HoltBosse\Form\Input;
+Use HoltBosse\DB\DB;
+
+$pageSize = Configuration::get_configuration_value ('general_options', 'pagination_size'); 
+
+$forms = DB::fetchall("SELECT * FROM form_instances WHERE state>=0");
+$formsCount = DB::fetch("SELECT COUNT(*) AS c FROM form_instances WHERE state>=0")->c;
+

--- a/src/admin/controllers/forms/views/all/style.css
+++ b/src/admin/controllers/forms/views/all/style.css
@@ -1,0 +1,103 @@
+table.table {
+	width:100%;
+}
+.position_single_wrap {
+	font-size:70%;
+	padding-top:0.3rem;
+	border-top:1px solid rgba(0,0,0,0.1);
+	margin-top:0.3rem;
+	opacity:0.6;
+}
+span.position_single {
+	font-weight:bold;
+}
+span.page_list, td.note_td, .lighter_note, .usage {
+	font-size:70%; opacity:0.6;
+}
+
+.state1 {
+	color:#00d1b2;
+}
+.state0 {
+	color:#f66;
+}
+.hidden_multi_edit {
+	display:none;
+}
+.content_admin_row.selected {
+	background:rgba(200,255,200,0.3);
+}
+
+table tr.droppable td {
+	height: 0;
+    padding: 0;
+    border: none;
+    margin: 0;
+    transition: all 0.3s ease;
+}
+
+table.dragging tr.droppable td {
+	height:1rem;
+	background:rgba(255,255,100,0.2);
+}
+table.dragging tr.droppable.ready {
+	height:2.2rem;
+	background:rgba(155,255,100,0.3);
+}
+.drag_td {
+	height: 0;
+}
+.center_state {
+	height: 100%;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+.before_after_wrap {
+	margin-right:0rem;
+	transition:all 0.3s ease;
+	width:0;
+	opacity:0;
+}
+
+.order_drop {
+	color: white;
+    background: #aad;
+    padding: 0.3em;
+    font-size: 0.7rem;
+    border-radius: 0.2rem;
+    text-transform: uppercase;
+    position: relative;
+    overflow: hidden;
+    display: inline-block;
+}
+.order_drop:first-child {
+	margin-bottom:0.5rem;
+}
+.order_drop.ready {
+	background:#ada;
+}
+
+tr.dragging {
+	opacity:0.3;
+}
+
+.grip {
+	margin-right:1rem;
+}
+table.dragging .before_after_wrap {
+	display:block;
+	margin-right:1rem;
+	width:auto;
+	max-width:15rem;
+	opacity:1;
+}
+
+td.limitwidth {
+    max-width: 50ch;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.form_field.field.field_id_old_url,.form_field.field.field_id_new_url {
+    width: 100%;
+}

--- a/src/admin/controllers/forms/views/all/view.php
+++ b/src/admin/controllers/forms/views/all/view.php
@@ -1,0 +1,92 @@
+<?php
+
+Use HoltBosse\Alba\Core\{CMS, User, Component};
+Use HoltBosse\Form\Input;
+Use HoltBosse\DB\DB;
+
+?>
+
+<style>
+	<?php echo file_get_contents(__DIR__ . "/style.css"); ?>
+</style>
+
+<?php
+	$rightContent = "<a class='is-primary pull-right button btn' href='" . $_ENV["uripath"] . "/admin/forms/edit/new'>New Form</a>";
+	Component::addon_page_title("Forms", null, $rightContent);
+?>
+
+<form action='' method='post' name='form_action' id='form_action_form'>
+
+<?php
+	$addonButtonGroupArgs = ["content_operations", "forms"];
+	Component::addon_button_toolbar($addonButtonGroupArgs);
+?>
+
+<?php if (!$forms):?>
+	<h2>No forms found.</h2>
+<?php else:?>
+
+	<table class='table'>
+		<thead>
+			<tr>
+				<th>State</th>
+				<th>Title</th>
+				<th>Created By</th>
+				<th>Updated By</th>
+			</tr>
+		</thead>
+		<tbody>
+			<?php foreach ($forms as $item):?>
+				<tr id='row_id_<?php echo $item->id;?>' data-itemid="<?php echo $item->id;?>" data-ordering="<?php echo $item->ordering;?>" class='content_admin_row'>
+					<td class='drag_td'>
+						<?php
+							Component::state_toggle($item->id, $item->state, "forms", NULL, -1);
+						?>
+					</td>
+					<td>
+						<div>
+							<a href="<?php echo $_ENV["uripath"]; ?>/admin/forms/edit/<?php echo $item->id;?>/<?php echo $item->content_type;?>"><?php echo Input::stringHtmlSafe($item->title); ?></a>
+						</div>
+						<span class='unimportant'>
+							<?php
+								echo $item->alias;
+							?>
+						</span>
+					</td>
+					<td><?php echo User::get_username_by_id($item->created_by); ?></td>
+					<td><?php echo User::get_username_by_id($item->updated_by); ?></td>
+				</tr>
+				
+			<?php endforeach; ?>
+		</tbody>
+	</table>
+<?php endif; ?>
+
+</form>
+
+<?php 
+
+$num_pages = ceil($formsCount/$pageSize);
+
+//$url_query_params = parse_url($_SERVER['REQUEST_URI'], PHP_URL_QUERY);
+$url_query_params = $_GET;
+$url_path = parse_url($_SERVER["REQUEST_URI"], PHP_URL_PATH);
+
+if ($cur_page) {
+	// not ordering view and page url is either 1 or no passed and assumed to be 1 in model
+	$url_query_params['page'] = $cur_page+1;
+	$next_url_params = http_build_query($url_query_params);
+	$url_query_params['page'] = $cur_page-1;
+	$prev_url_params = http_build_query($url_query_params);
+	/* CMS::pprint_r ($url_query_params);
+	CMS::pprint_r ($next_url_params); */
+}
+
+?>
+
+<?php Component::create_pagination($formCount, $pageSize, $cur_page); ?>
+
+<script type="module">
+	import {handleAdminRows} from "/js/admin_row.js";
+	handleAdminRows(".content_admin_row");
+</script>

--- a/src/admin/controllers/forms/views/api/model.php
+++ b/src/admin/controllers/forms/views/api/model.php
@@ -1,0 +1,4 @@
+<?php
+
+ob_get_clean();
+ob_get_clean();

--- a/src/admin/controllers/forms/views/api/view.php
+++ b/src/admin/controllers/forms/views/api/view.php
@@ -32,7 +32,6 @@ function generateFormForFieldType($fieldType): Form {
                     "description"=>$attrInstance->description ?? null,
                 ];
 
-                //@phpstan-ignore-next-line
                 if($attrInstance->dataType === FormBuilderDataType::Bool && $attrInstance->fieldType == "Select") {
                     $field->select_options = [
                         (object) ["value"=>1, "text"=>"True"],
@@ -40,7 +39,6 @@ function generateFormForFieldType($fieldType): Form {
                     ];
                 }
 
-                //@phpstan-ignore-next-line
                 if($attrInstance->dataType === FormBuilderDataType::LetterString && $attrInstance->fieldType == "Text") {
                     $field->pattern = "^[a-z]+$";
                     $field->description = "Only letters (a-z) are allowed.";

--- a/src/admin/controllers/forms/views/api/view.php
+++ b/src/admin/controllers/forms/views/api/view.php
@@ -1,0 +1,118 @@
+<?php
+
+use HoltBosse\Alba\Core\{CMS, Form};
+use \ReflectionClass;
+use HoltBosse\Form\FormBuilderDataType;
+
+function generateFormForFieldType($fieldType): Form {
+    $formObject = (object) [
+        "id"=>"fieldconfig",
+        "fields"=>[]
+    ];
+
+    $reflection = new ReflectionClass(Form::getFieldClass($fieldType));
+
+    foreach ($reflection->getProperties() as $property) {
+        $attributes = $property->getAttributes();
+        if(sizeof($attributes) == 0) {
+            continue;
+        }
+        //CMS::pprint_r($property->getName());
+
+        foreach ($attributes as $attribute) {
+            if($attribute->getName() == "HoltBosse\Form\FormBuilderAttribute") {
+                $attrInstance = $attribute->newInstance();
+                //CMS::pprint_r($attrInstance);
+
+                $field = (object) [
+                    "name"=>$property->getName(),
+                    "type"=>$attrInstance->fieldType,
+                    "label"=>$attrInstance->label ?? ucwords(str_replace("_", " ", $property->getName())),
+                    "required"=>$attrInstance->required,
+                    "description"=>$attrInstance->description ?? null,
+                ];
+
+                //@phpstan-ignore-next-line
+                if($attrInstance->dataType === FormBuilderDataType::Bool && $attrInstance->fieldType == "Select") {
+                    $field->select_options = [
+                        (object) ["value"=>1, "text"=>"True"],
+                        (object) ["value"=>0, "text"=>"False"]
+                    ];
+                }
+
+                //@phpstan-ignore-next-line
+                if($attrInstance->dataType === FormBuilderDataType::LetterString && $attrInstance->fieldType == "Text") {
+                    $field->pattern = "^[a-z]+$";
+                    $field->description = "Only letters (a-z) are allowed.";
+                }
+
+                $formObject->fields[] = $field;
+            }
+            /* CMS::pprint_r($attribute);
+            $attrInstance = $attribute->newInstance();
+            CMS::pprint_r($attrInstance); */
+        }
+    }
+
+    $formObject->fields[] = (object) [
+        "type"=>"Html",
+        "html"=>"<br><div class='button is-primary field-update'>Update Field</div>"
+    ];
+
+    $form = new Form($formObject);
+    return $form;
+}
+
+function getFieldOptionsForm(Form $form, string $fieldType, string $prefixMarkup=""): string {
+    $formMarkup = "";
+    $formMarkup .= "<form style='width: 100%;' onsubmit='return false;' action='/admin/forms/api/fieldoptionsformsubmit/$fieldType'>";
+        $formMarkup .= $prefixMarkup;
+        ob_start();
+            $form->display();
+        $formMarkup.= ob_get_clean();
+    $formMarkup.= "</form>";
+    return $formMarkup;
+}
+
+$segments = CMS::Instance()->uri_segments;
+
+if(sizeof($segments)==4 && $segments[2]=="fieldoptions") {
+    $jsonConfig = json_decode(file_get_contents(__DIR__ . "/../edit/config.json"));
+
+    //CMS::pprint_r($_POST);
+
+    if($segments[3]=="none") {
+        echo "<p>Select Field</p>";
+    } elseif(in_array($segments[3], $jsonConfig->allowedFields)) {
+        $index = isset($_GET["index"]) ? intval($_GET["index"]) : 0; //intval forces to 0 if junk
+
+        $form = generateFormForFieldType($segments[3]);
+        $form->deserializeJson($_POST["fieldtypes"][$index]);
+        echo getFieldOptionsForm($form, $segments[3]);
+    } else {
+        echo "<p>Unknown Field Type</p>";
+    }
+} elseif(sizeof($segments)==4 && $segments[2]=="fieldoptionsformsubmit") {
+    $form = generateFormForFieldType($segments[3]);
+    $form->setFromSubmit();
+
+    if($form->validate()) {
+        $response = (object) [
+            "status"=>1,
+            "data"=>json_encode($form),
+            "html"=>"",
+        ];
+
+        echo json_encode($response);
+    } else {
+        $response = (object) [
+            "status"=>0,
+            "data"=>"{}",
+            "html"=>getFieldOptionsForm($form, $segments[3], "<div class='alert notification is-danger'>invalid form field</div>" . print_r($_POST, true)),
+        ];
+
+        echo json_encode($response);
+    }
+}
+
+die;

--- a/src/admin/controllers/forms/views/edit/config.json
+++ b/src/admin/controllers/forms/views/edit/config.json
@@ -1,0 +1,9 @@
+{
+    "allowedFields": [
+        "Text",
+        "Textarea",
+        "Checkbox",
+        "Antispam",
+        "Honeypot"
+    ]
+}

--- a/src/admin/controllers/forms/views/edit/model.php
+++ b/src/admin/controllers/forms/views/edit/model.php
@@ -1,0 +1,179 @@
+<?php
+
+use HoltBosse\Alba\Core\{CMS, Form};
+use HoltBosse\Alba\Fields\UserPicker\UserPicker;
+use HoltBosse\Alba\Fields\PageSelect\PageSelect;
+use \Exception;
+use HoltBosse\Form\{Input, FormBuilderAttribute};
+use HoltBosse\DB\DB;
+
+$segments = CMS::Instance()->uri_segments;
+$formConfigPath = $_ENV["root_path_to_forms"] . "/forms/";
+
+if(!is_dir($formConfigPath)) {
+    mkdir($formConfigPath, 0755, true);
+}
+
+if(sizeof($segments)==3 && is_numeric($segments[2])){
+    $formId = intval($segments[2]);
+} elseif(sizeof($segments)==3 && $segments[2]=="new"){
+    $formId = null;
+} else {
+    CMS::Instance()->queue_message('Unknown form operation','danger',$_ENV["uripath"].'/admin');
+	exit(0);
+}
+
+$requiredDetailsForm = new Form(__DIR__ . "/required_fields_form.json");
+
+CMS::Instance()->head_entries[] = '<script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.7/dist/htmx.min.js"></script>';
+
+$emailField = new UserPicker();
+$emailField->loadFromConfig((object) [
+    "name"=>"emails",
+    "id"=>"emails",
+    "label"=>"Email",
+    "type"=>"UserPicker",
+    "description"=>"Select users to notify when this form is submitted",
+    "required"=>false,
+    "multiple"=>true
+]);
+
+$formSubmitPageField = new PageSelect();
+$formSubmitPageField->loadFromConfig((object) [
+    "name"=>"form_submit_page",
+    "id"=>"form_submit_page",
+    "label"=>"Form Submit Page",
+    "type"=>"PageSelect",
+    "description"=>"Select the page to redirect to after form submission",
+    "required"=>true,
+    "multiple"=>false,
+    "slimselect"=>true,
+]);
+
+if($formId) {
+    $formData = DB::fetch("SELECT * FROM form_instances WHERE id=?", [$formId]);
+
+    if(!$formData) {
+        CMS::Instance()->queue_message('Form not found','danger',$_ENV["uripath"].'/admin/forms/all');
+        exit(0);
+    }
+
+    $requiredDetailsForm->getFieldByName("title")->default = $formData->title;
+    $requiredDetailsForm->getFieldByName("alias")->default = $formData->alias;
+    $requiredDetailsForm->getFieldByName("state")->default = $formData->state;
+
+    if(!empty($formData->emails)) {
+        $emailField->default = json_encode(explode(",", $formData->emails));
+    }
+
+    $formSubmitPageField->default = $formData->submit_page;
+}
+
+if($requiredDetailsForm->isSubmitted()) {
+    $requiredDetailsForm->setFromSubmit();
+
+    if($requiredDetailsForm->validate()/* check for form details??? */) {
+        $aliasField = $requiredDetailsForm->getFieldByName("alias");
+        if(empty($aliasField->default)) {
+            $aliasField->default = Input::makeAlias($requiredDetailsForm->getFieldByName("title")->default);
+            
+            $aliasExists = DB::fetch("SELECT id FROM form_instances WHERE alias=?", [$aliasField->default]);
+            if($aliasExists) {
+                $aliasField->default .= "-" . uniqid();
+
+                CMS::Instance()->queue_message('Added random suffix to "URL Friendly" field to ensure uniqueness.','warning');
+            }
+        }
+
+
+        $formFields = [];
+
+        foreach($_POST["fields"] as $index=>$fieldType) {
+            if(!empty($_POST["fieldtypes"][$index])) {
+                try {
+                    $fieldDetails = json_decode($_POST["fieldtypes"][$index], null, 512, JSON_THROW_ON_ERROR);
+                    $normalizedDetails = array_combine(array_column($fieldDetails, 'name'), array_column($fieldDetails, 'value'));
+                } catch(Exception $e) {
+                    continue;
+                }
+
+                CMS::pprint_r($normalizedDetails);
+
+                if(!empty(Form::getFieldClass($fieldType))) {
+                    $fieldReflection = new ReflectionClass(Form::getFieldClass($fieldType));
+                    //$propertiesWithAttributes = [];
+                    $fieldInstance = [];
+
+                    foreach ($fieldReflection->getProperties() as $property) {
+                        //@phpstan-ignore-next-line
+                        $attributes = $property->getAttributes(FormBuilderAttribute::class);
+                        if (!empty($attributes)) {
+                            $fieldInstance[$property->getName()] = $normalizedDetails[$property->getName()] ?? null;
+                        }
+                    }
+
+                    $fieldInstance["type"] = $fieldType;
+
+                    $formFields[] = (object) $fieldInstance;
+                }
+            }
+        }
+
+        if(empty($formFields)) {
+            CMS::Instance()->queue_message('At least one form field is required','danger', $_ENV["uripath"].'/admin/forms/all');
+            exit(0);
+        }
+
+        if($formId) {
+            DB::exec(
+                "UPDATE form_instances SET title=?, alias=?, updated_by=?, emails=?, submit_page=? WHERE id=?",
+                [
+                    $requiredDetailsForm->getFieldByName("title")->default,
+                    $aliasField->default,
+                    CMS::Instance()->user->id,
+                    !empty($_POST["emails"]) ? implode(",", $_POST["emails"]) : null,
+                    $_POST["form_submit_page"] ?? null,
+                    $formId
+                ]
+            );
+        } else {
+            DB::exec(
+                "INSERT INTO form_instances (title, alias, created_by, updated_by, emails, submit_page, location, state) VALUES (?,?,?,?,?,?,?,?)",
+                [
+                    $requiredDetailsForm->getFieldByName("title")->default,
+                    $aliasField->default,
+                    CMS::Instance()->user->id,
+                    CMS::Instance()->user->id,
+                    !empty($_POST["emails"]) ? implode(",", $_POST["emails"]) : null,
+                    $_POST["form_submit_page"] ?? null,
+                    "", //create this below
+                    1
+                ]
+            );
+
+            $formId = DB::getLastInsertedId();
+
+            DB::exec(
+                "UPDATE form_instances SET location=? WHERE id=?",
+                [
+                    "/forms/form_instance_" . $formId,
+                    $formId
+                ]
+            );
+        }
+
+        $formObject = (object) [
+            "id"=>"form_instance_" . $formId,
+            "display_name"=>$requiredDetailsForm->getFieldByName("title")->default,
+            "fields"=>$formFields
+        ];
+
+        $fileHandle = fopen($formConfigPath . "form_instance_" . $formId . ".json", "w");
+        fwrite($fileHandle, json_encode($formObject, JSON_PRETTY_PRINT));
+        fclose($fileHandle);
+
+        CMS::Instance()->queue_message('Form saved successfully','success',$_ENV["uripath"].'/admin/forms/all');
+    } else {
+        CMS::Instance()->queue_message('Invalid form','danger');
+    }
+}

--- a/src/admin/controllers/forms/views/edit/model.php
+++ b/src/admin/controllers/forms/views/edit/model.php
@@ -105,7 +105,6 @@ if($requiredDetailsForm->isSubmitted()) {
                     $fieldInstance = [];
 
                     foreach ($fieldReflection->getProperties() as $property) {
-                        //@phpstan-ignore-next-line
                         $attributes = $property->getAttributes(FormBuilderAttribute::class);
                         if (!empty($attributes)) {
                             $fieldInstance[$property->getName()] = $normalizedDetails[$property->getName()] ?? null;

--- a/src/admin/controllers/forms/views/edit/required_fields_form.json
+++ b/src/admin/controllers/forms/views/edit/required_fields_form.json
@@ -1,0 +1,36 @@
+{
+	"id": "required_form_fields",
+	"fields": [
+		{
+			"label":"Content Title",
+			"name":"title",
+			"id":"title",
+			"type":"Text",
+			"required":true,
+			"maxlength":255,
+			"filter": "RAW"
+		},
+		{
+			"label":"URL Friendly",
+			"name":"alias",
+			"id":"alias",
+			"type":"Text",
+			"filter":"ALIAS",
+			"maxlength":255,
+			"description":""
+		},
+		{
+			"name": "state",
+			"id": "state",
+			"type": "Select",
+			"label": "Form State",
+			"description": "Choose to show form or not globally.",
+			"filter": "NUMBER",
+			"default":1,
+			"select_options":[
+				{"value":1,"text":"Published"},
+				{"value":0,"text":"Unpublished"}
+			]
+		}
+	]
+}

--- a/src/admin/controllers/forms/views/edit/script.js
+++ b/src/admin/controllers/forms/views/edit/script.js
@@ -1,0 +1,149 @@
+function createFieldDiv(fieldType) {
+    const id = `id_${crypto.randomUUID()}`;
+    const numFieldTypes = document.querySelectorAll("input.fieldtype").length;
+
+    const div = document.createElement("div");
+    div.classList.add("field-item");
+    div.id = id;
+    div.dataset.fieldType = fieldType;
+    div.innerHTML = `
+        <h5 class="title is-5">Unnamed Field</h5>
+        <p class='unimportant'>Type: ${fieldType}</p>
+        <span class="close-me">&times;</span>
+        <input type='hidden' class="fieldtype" name='fieldtypes[]'>
+        <input type='hidden' class="fields" name='fields[]' value='${fieldType}'>
+    `;
+    div.setAttribute("hx-trigger", "click");
+    div.setAttribute("hx-post", `/admin/forms/api/fieldoptions/${fieldType}?index=${numFieldTypes}`);
+    div.setAttribute("hx-target", ".control-panel");
+    div.setAttribute("hx-swap", "innerHTML");
+    div.setAttribute("hx-include", `input.fieldtype`);
+
+    htmx.process(div);
+
+    return div;
+}
+
+document.querySelector(".new-field-select").addEventListener("change", (e) => {
+    const value = e.target.value;
+    
+    e.preventDefault();
+    event.target.value = "";
+
+    console.log(value);
+
+    const div = createFieldDiv(value);
+
+    htmx.process(div);
+
+    document.querySelector(".fields-panel").appendChild(div);
+});
+
+document.querySelector(".fields-panel").addEventListener("click", (e) => {
+    const fieldItem = e.target.closest(".field-item");
+    if (!fieldItem) return;
+
+    document.querySelector(".field-item.selected")?.classList.remove("selected");
+
+    fieldItem.classList.toggle("selected");
+});
+
+document.querySelector(".fields-panel").addEventListener("click", (e) => {
+    if(e.target.classList.contains("close-me")) {
+        const fieldItem = e.target.closest(".field-item");
+        if (!fieldItem) return;
+
+        if(fieldItem.classList.contains("selected")) {
+            clear_selection();
+        }
+
+        fieldItem.remove();
+    }
+});
+
+function clear_selection() {
+    document.querySelector(".field-item.selected")?.classList.remove("selected");
+
+    htmx.ajax("POST", `/admin/forms/api/fieldoptions/none`, ".control-panel");
+}
+
+document.addEventListener('keydown', (e)=>{
+    if (e.key === "Escape" || e.key === "Esc") {
+        clear_selection();
+    }
+});
+
+document.addEventListener('click', (e)=>{
+    if (!e.target.closest('.field-item') && !e.target.closest('.control-panel')) {
+        clear_selection();
+    }
+});
+
+function updateFieldDiv(field, label, fieldData) {
+    field.querySelector("h5").innerText = label || "Unnamed Field";
+    field.querySelector("input.fieldtype").value = fieldData;
+
+    return field
+}
+
+document.querySelector(".control-panel").addEventListener("click", (e) => {
+    if(e.target.classList.contains("button") && e.target.classList.contains("field-update")) {
+        const form = e.target.closest("form");
+
+        const formStatus = form.reportValidity();
+        if (!formStatus) return;
+
+        const formData = new FormData(form);
+
+        fetch(form.action, {
+            method: "POST",
+            body: formData
+        }).then(response => response.json()).then(res => {
+            if(res.status==0) {
+                htmx.swap(".control-panel", res.html, {swap:"innerHTML"});
+            } else if(res.status==1) {
+                const selectedField = document.querySelector(".field-item.selected");
+                selectedField.classList.remove("selected");
+
+                updateFieldDiv(selectedField, formData.get("label"), res.data);
+                
+                //console.log("yay");
+                //console.log(res);
+
+                htmx.ajax("POST", `/admin/forms/api/fieldoptions/none`, ".control-panel");
+            } else {
+                console.log(res);
+                alert("unable to update form!");
+            }
+        });
+    }
+});
+
+window.addEventListener("load", ()=>{
+    if(window.existingFormData) {
+        const formData = window.existingFormData;
+        const formFields = formData.fields || [];
+
+        formFields.forEach((fieldData)=>{
+            const fieldDiv = createFieldDiv(fieldData.type);
+
+            document.querySelector(".fields-panel").appendChild(fieldDiv);
+
+            //remove type from fieldData
+            delete fieldData.type;
+
+            const convertedFieldData = [];
+
+            for (const [key, value] of Object.entries(fieldData)) {
+                convertedFieldData.push({
+                    name: key,
+                    value: value
+                });
+            }
+
+            //update field div with data
+            updateFieldDiv(fieldDiv, fieldData.label, JSON.stringify(convertedFieldData));
+        });
+
+    }
+});

--- a/src/admin/controllers/forms/views/edit/style.css
+++ b/src/admin/controllers/forms/views/edit/style.css
@@ -1,0 +1,128 @@
+:root {
+    --form-background-color: rgb(226, 228, 233);
+}
+
+@media(prefers-color-scheme: dark) {
+    :root {
+        --form-background-color: rgb(31, 34, 41);
+    }
+}
+
+div.flex > .form_contain#required_form_fields {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
+    gap: 0.5rem 2rem;
+    width: 100%;
+
+    select {
+        width: 100%;
+    }
+
+    div.form_field {
+        margin-bottom: 0;
+    }
+
+    div.field_id_tags, div.field_id_category {
+        grid-column: span 2;
+    }
+}
+div.flex > * {
+    min-width: 2rem;
+}
+
+.form-builder {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: 1fr 3fr;
+
+    .control-panel {
+        padding: 1rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: var(--form-background-color);
+
+        select {
+            width: 100%;
+        }
+
+        & > * {
+            position: sticky;
+            top: 6rem;
+        }
+    }
+
+    .fields-panel {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+
+        .field-item {
+            padding: 1rem;
+            background: var(--form-background-color);
+            cursor: pointer;
+            position: relative;
+
+            border: 2px solid transparent;
+
+            &.selected {
+                border-color: yellow;
+            }
+
+            .close-me {
+                position: absolute;
+                top: 0.5rem;
+                right: 0.5rem;
+                cursor: pointer;
+                font-size: 1.5rem;
+                line-height: 1;
+            }
+        }
+
+        .new-field {
+            background: var(--form-background-color);
+            padding: 1rem;
+            position: sticky;
+            top: 0;
+            z-index: 3;
+            box-shadow: 0 4px 6px -4px grey;
+
+            .new-field-gui-container {
+                position: relative;
+
+                .plus-button {
+                    background-color: var(--form-background-color);
+                    position: relative;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    pointer-events: none;
+                    z-index: 2;
+
+                    i {
+                        cursor: pointer;
+                        padding: 0.5rem;
+                        font-size: 2rem;
+                    }
+                }
+
+                select {
+                    position: absolute;
+                    top: 0rem;
+                    left: 0rem;
+                    right: 0rem;
+                    width: 100%;
+                    height: 3rem;
+
+                    &:focus-visible {
+                        outline: none;
+                    }
+
+                    [value=""] {
+                        display: none;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/admin/controllers/forms/views/edit/view.php
+++ b/src/admin/controllers/forms/views/edit/view.php
@@ -1,0 +1,67 @@
+<?php
+    use HoltBosse\Alba\Core\{CMS, Component};
+?>
+
+<style>
+    <?php echo file_get_contents(__DIR__ . "/style.css"); ?>
+</style>
+
+<form action="" method="post">
+
+    <a href='#' class='toggle_siblings'>show/hide required fields</a>
+    <div class='toggle_wrap '>
+        <div class='flex'>
+            <?php $requiredDetailsForm->display(); ?>
+        </div>
+    </div>
+
+    <br><br>
+
+    <label class="label">Form Builder</label>
+    <section class="form-builder">
+        <div class="control-panel">
+            <p>Select Field</p>
+        </div>
+        <div class="fields-panel">
+            <div class="new-field">
+                <div class="new-field-gui-container">
+                    <div class="plus-button">
+                        <i class="fa-solid fa-square-plus"></i>
+                    </div>
+                    <select class="new-field-select">
+                        <option value="">Select Field Type</option>
+                        <?php
+                            $jsonConfig = json_decode(file_get_contents(__DIR__ . "/config.json"));
+                            foreach($jsonConfig->allowedFields as $fieldType) {
+                                echo "<option value='$fieldType'>" . ucwords($fieldType) . "</option>";
+                            }
+
+                            if($formId) {
+                                $formFields = file_get_contents($_ENV["root_path_to_forms"] . "/forms/form_instance_" . $formId . ".json");
+                                echo "<script> window.existingFormData = $formFields;</script>";
+                            }
+                        ?>
+                    </select>
+                <div>
+            </div>
+        </div>
+    </section>
+
+    <br><br>
+
+
+    <?php
+        $emailField->display();
+
+        $formSubmitPageField->display();
+    ?>
+    <input type="hidden" name="form_configuration_submission" value='1'>
+
+    <?php
+        Component::create_fixed_control_bar();
+    ?>
+</form>
+
+<script>
+    <?php echo file_get_contents(__DIR__ . "/script.js"); ?>
+</script>

--- a/src/admin/controllers/settings/views/updates/model.php
+++ b/src/admin/controllers/settings/views/updates/model.php
@@ -173,6 +173,26 @@ if (!$messages_table_ok) {
 	");
 }
 
+// ensure form_instances table exists
+$form_instances_table_ok = DB::fetchAll("SELECT * FROM information_schema.COLUMNS WHERE TABLE_NAME = 'form_instances' LIMIT 1");
+if(!$form_instances_table_ok) {
+	DB::exec("DROP TABLE IF EXISTS `form_instances`;");
+	DB::exec(
+		"CREATE TABLE `form_instances` (
+			`id` int(11) NOT NULL AUTO_INCREMENT,
+			`state` tinyint(4) NOT NULL DEFAULT 1,
+			`title` varchar(255) NOT NULL,
+			`alias` varchar(255) NOT NULL,
+			`created_by` int(11) NOT NULL,
+			`updated_by` int(11) NOT NULL,
+			`emails` varchar(255) DEFAULT NULL,
+			`submit_page` varchar(255) DEFAULT NULL,
+			`location` varchar(255) NOT NULL,
+			PRIMARY KEY (`id`)
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;"
+	);
+}
+
 $content_table_ordering_ok = true;
 $contentTypes = Content::get_all_content_types();
 foreach($contentTypes as $type) {

--- a/src/admin/controllers/settings/views/updates/view.php
+++ b/src/admin/controllers/settings/views/updates/view.php
@@ -92,6 +92,13 @@ else {
 	show_message ('Messages Table','Messages table created.','is-warning');
 }
 
+if ($form_instances_table_ok) {
+	show_message ('Form Instances Table','Form Instances table OK.','is-success');
+}
+else {
+	show_message ('Form Instances Table','Form Instances table created.','is-warning');
+}
+
 if($content_table_ordering_ok) {
 	show_message ('Content Table(s)','Content Ordering OK.','is-success');
 }

--- a/src/admin/templates/clean/navigation.php
+++ b/src/admin/templates/clean/navigation.php
@@ -87,6 +87,7 @@ $navigation = [
             "label"=>"forms",
             "links"=>[
                 "submissions"=>"/admin/forms/submissions",
+                "forms"=>"/admin/forms/all",
             ]
         ]
     ],


### PR DESCRIPTION
adds a mvp dynamic form builder supporting text, textarea, checkbox, antispam, and honeypot fields with minimal configuration. additionally adds a forminstance widget so forms can be rendered, responses collected, and emailed in a widget position

* [x] depends on https://github.com/HoltBosse/form/pull/14 being merged, tagged, and cms updated to required that version.
* [x] after that this pr can be rebased on phpstan ignore comments removed

