### PR TITLE
trashfire: toss last remenants of content_versions

### DIFF
--- a/bin/sql/mariadb/content_versions.sql
+++ b/bin/sql/mariadb/content_versions.sql
@@ -1,8 +1,0 @@
-CREATE TABLE `content_versions` (
-  `id` int NOT NULL AUTO_INCREMENT,
-  `content_id` int NOT NULL,
-  `created_by` int NOT NULL,
-  `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `fields_json` mediumtext NOT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/admin/controllers/settings/views/general/general_options.json
+++ b/src/admin/controllers/settings/views/general/general_options.json
@@ -39,16 +39,6 @@
 			"filter": "NUM"
 		},
 		{
-			"name": "content_versions",
-			"id": "content_versions",
-			"type": "Text",
-			"label": "Version Save Count",
-			"required": true,
-			"description": "Enter the number of content versions to save. Entering 0 will save none and will use the least database space.",
-			"default":1,
-			"filter": "NUM"
-		},
-		{
 			"type":"Tab",
 			"mode":"tabend"
 		},


### PR DESCRIPTION
does what it says on the tin - this never worked and was always broken and in recent years wasnt being used at all. now has been replaced with a working solution in https://github.com/HoltBosse/Alba/pull/657