### PR TITLE
feat: harden get and posts variable direct access

### DIFF
--- a/src/Core/User.php
+++ b/src/Core/User.php
@@ -5,6 +5,7 @@ Use HoltBosse\DB\DB;
 Use HoltBosse\Form\Input;
 Use \Exception;
 use \PDOException;
+Use Respect\Validation\Validator as v;
 
 class User {
 	public $id;
@@ -105,13 +106,10 @@ class User {
 
 	public function load_from_post() {
 		$this->username = Input::getvar('username','RAW');
-		if (isset($_POST['password'])) {
-			if ($_POST['password']) {
-				$this->password = password_hash ($_POST['password'], PASSWORD_DEFAULT); 
-			}
-			else {
-				$this->password = null;
-			}
+
+		$submittedPassword = Input::getvar('password',v::StringVal(),null);
+		if ($submittedPassword) {
+			$this->password = password_hash ($submittedPassword, PASSWORD_DEFAULT); 
 		}
 		else {
 			$this->password = null;

--- a/src/admin/controllers/audit/views/default/model.php
+++ b/src/admin/controllers/audit/views/default/model.php
@@ -3,8 +3,10 @@
 Use HoltBosse\Alba\Core\{CMS, Configuration, Actions};
 Use HoltBosse\Form\Form;
 Use HoltBosse\DB\DB;
+Use HoltBosse\Form\Input;
+Use Respect\Validation\Validator as v;
 
-$cur_page = $_GET["page"] ?? 1;
+$cur_page = Input::getVar("page", v::numericVal(), 1);
 $pagination_size = Configuration::get_configuration_value ('general_options', 'pagination_size') ?? 10;
 
 $event_types = DB::fetchAll("SELECT DISTINCT `type` AS text, `type` AS value FROM user_actions");

--- a/src/admin/controllers/content/views/all/model.php
+++ b/src/admin/controllers/content/views/all/model.php
@@ -3,6 +3,7 @@
 Use HoltBosse\Alba\Core\{CMS, JSON, Controller, Configuration, Tag, Content, ContentSearch};
 Use HoltBosse\DB\DB;
 Use HoltBosse\Form\Input;
+Use Respect\Validation\Validator as v;
 
 $segments = CMS::Instance()->uri_segments;
 $search = Input::getvar('search','RAW',null);
@@ -115,7 +116,7 @@ function make_sortable_header($title) {
 				<i class="tableorder fas fa-sort-up"></i>
 				<i class="tableorder fas fa-sort-down"></i>
 			</label>
-			<?php $selectedTitle = $_GET[str_replace(" ", "_", $title) . "_order"] ?? "regular"; ?>
+			<?php $selectedTitle = Input::getVar(str_replace(" ", "_", $title) . "_order", v::StringVal()->in(["asc", "desc", "regular"]), "regular");?>
 			<input type="radio" name="<?php echo str_replace(" ", "_", $title); ?>_order" form="orderform" value="regular" <?php echo $selectedTitle=="regular" ? "checked" : ""; ?> />
 			<input type="radio" name="<?php echo str_replace(" ", "_", $title); ?>_order" form="orderform" value="asc" <?php echo $selectedTitle=="asc" ? "checked" : ""; ?> />
 			<input type="radio" name="<?php echo str_replace(" ", "_", $title); ?>_order" form="orderform" value="desc" <?php echo $selectedTitle=="desc" ? "checked" : ""; ?> />

--- a/src/admin/controllers/content/views/all/view.php
+++ b/src/admin/controllers/content/views/all/view.php
@@ -167,7 +167,7 @@ Use HoltBosse\Form\Fields\Select\Select as Field_Select;
 				?>
 				<?php
 					//if in ordering mode or search, disable content listing order controls
-					if(isset($_GET["filters"])) {
+					if(Input::getVar("filters", "RAW", null)) {
 						echo "<style>
 								.orderablerow{
 									pointer-events: none;

--- a/src/admin/controllers/content/views/edit/model.php
+++ b/src/admin/controllers/content/views/edit/model.php
@@ -3,6 +3,7 @@
 Use HoltBosse\Alba\Core\{CMS, Content, Hook};
 Use HoltBosse\DB\DB;
 Use HoltBosse\Form\{Form, Input};
+Use Respect\Validation\Validator as v;
 
 $segments = CMS::Instance()->uri_segments;
 
@@ -26,12 +27,9 @@ if (sizeof($segments)==4 && is_numeric($segments[2]) && is_numeric($segments[3])
 	}
 	$new_content = false;
 
-	if(!empty($_GET["revision"])) {
-		if(!is_numeric($_GET["revision"])) {
-			CMS::Instance()->queue_message('Failed to load invalid revision',$_ENV["uripath"].'/admin/content/all/' . $content_type);
-		}
-
-		$revisionId = (int) $_GET["revision"];
+	$revision = Input::getVar("revision", v::numericVal(), null);
+	if($revision) {
+		$revisionId = (int) $revision;
 
 		$revisions = DB::fetchall(
 			"SELECT ua.date, uad.json

--- a/src/admin/controllers/forms/views/api/view.php
+++ b/src/admin/controllers/forms/views/api/view.php
@@ -3,6 +3,8 @@
 use HoltBosse\Alba\Core\{CMS, Form};
 use \ReflectionClass;
 use HoltBosse\Form\FormBuilderDataType;
+Use HoltBosse\Form\Input;
+Use Respect\Validation\Validator as v;
 
 function generateFormForFieldType($fieldType): Form {
     $formObject = (object) [
@@ -77,15 +79,14 @@ $segments = CMS::Instance()->uri_segments;
 if(sizeof($segments)==4 && $segments[2]=="fieldoptions") {
     $jsonConfig = json_decode(file_get_contents(__DIR__ . "/../edit/config.json"));
 
-    //CMS::pprint_r($_POST);
-
     if($segments[3]=="none") {
         echo "<p>Select Field</p>";
     } elseif(in_array($segments[3], $jsonConfig->allowedFields)) {
-        $index = isset($_GET["index"]) ? intval($_GET["index"]) : 0; //intval forces to 0 if junk
+        $index = Input::getVar("index", v::numericVal(), 0);
+        $submittedFieldTypes = Input::getVar("fieldtypes", v::ArrayType(), []);
 
         $form = generateFormForFieldType($segments[3]);
-        $form->deserializeJson($_POST["fieldtypes"][$index]);
+        $form->deserializeJson($submittedFieldTypes[$index]);
         echo getFieldOptionsForm($form, $segments[3]);
     } else {
         echo "<p>Unknown Field Type</p>";

--- a/src/admin/controllers/forms/views/submissions/model.php
+++ b/src/admin/controllers/forms/views/submissions/model.php
@@ -3,6 +3,7 @@
 Use HoltBosse\Alba\Core\{CMS, Configuration};
 Use HoltBosse\Form\{Input, Form};
 Use HoltBosse\DB\DB;
+Use Respect\Validation\Validator as v;
 
 $segments = CMS::Instance()->uri_segments;
 if(sizeof($segments) > 2) {
@@ -32,7 +33,7 @@ $formSelectOptions = array_map(function($input) {
 $searchFieldsObject = json_decode(file_get_contents(__DIR__ . "/search_fields.json"));
 $searchFieldsObject->fields[0]->select_options = $formSelectOptions;
 // @phpstan-ignore-next-line
-if(!isset($_GET["form"]) && $searchFieldsObject->fields[0]->select_options[0]) {
+if(Input::getVar("form", v::StringVal(), null)==null && $searchFieldsObject->fields[0]->select_options[0]) {
     $searchFieldsObject->fields[0]->default = $searchFieldsObject->fields[0]->select_options[0]->value;
 }
 $searchFieldsObject->fields[] = (object) [
@@ -95,7 +96,7 @@ if($results[0]) {
     $currentSelectedForm = new Form($currentSelectedObject);
 }
 
-if($_GET["exportcsv"]) {
+if(Input::getVar("exportcsv", v::NumericVal(), 0) == 1) {
     ob_get_clean();
     ob_get_clean();
 

--- a/src/admin/controllers/forms/views/submissions/view.php
+++ b/src/admin/controllers/forms/views/submissions/view.php
@@ -2,16 +2,17 @@
 
 Use HoltBosse\Alba\Core\{CMS, Component};
 Use HoltBosse\Form\Input;
+Use Respect\Validation\Validator as v;
 
 echo "<style>";
     echo file_get_contents(__DIR__ . "/style.css");
 echo "</style>";
 
+$currentForm = Input::getVar("form", v::StringVal()->length(1, null), null) ?? $searchFieldsObject->fields[0]->select_options[0]->value ?? null;
+
 $titleText = "Form Submissions";
-if($_GET["form"]) {
-    $titleText = 'All “' . Input::stringHtmlSafe($_GET["form"]) . '” form submissions';
-} elseif($searchFieldsObject->fields[0]->select_options[0]->value) {
-    $titleText = 'All “' . $searchFieldsObject->fields[0]->select_options[0]->value . '” form submissions';
+if($currentForm) {
+    $titleText = 'All “' . Input::stringHtmlSafe($currentForm) . '” form submissions';
 }
 
 $urlQueryParams = $_GET;

--- a/src/admin/controllers/pages/views/save/model.php
+++ b/src/admin/controllers/pages/views/save/model.php
@@ -3,6 +3,7 @@
 Use HoltBosse\Alba\Core\{CMS, Content, Page, Template};
 Use HoltBosse\DB\DB;
 Use HoltBosse\Form\{Form, Input};
+Use Respect\Validation\Validator as v;
 
 // any variables created here will be available to the view
 
@@ -81,9 +82,12 @@ $success = $page->save();
 
 if ($success) {
 	// save widget overrides
-	// unique key on page, template and position in table	
-	for ($n=0; $n < sizeof ($_POST['override_positions_widgets']); $n++ ) {
-		$data = [$page->id, $_POST['override_positions'][$n], $_POST['override_positions_widgets'][$n], $page->id, $_POST['override_positions'][$n], $_POST['override_positions_widgets'][$n]];
+	// unique key on page, template and position in table
+	$overridePositionsWidgets = Input::getVar('override_positions_widgets', v::arrayType()->each(v::optional(v::numericVal())), []);
+	$overridePositions = Input::getVar('override_positions', v::arrayType()->each(v::optional(v::StringVal())), []);
+
+	for ($n=0; $n < sizeof ($overridePositionsWidgets); $n++ ) {
+		$data = [$page->id, $overridePositions[$n], $overridePositionsWidgets[$n], $page->id, $overridePositions[$n], $overridePositionsWidgets[$n]];
 		$override_success = DB::exec("insert into page_widget_overrides (page_id, position, widgets) values (?,?,?) on duplicate key update page_id=?, position=?, widgets=?", $data);
 	}
 

--- a/src/admin/controllers/plugins/views/edit/model.php
+++ b/src/admin/controllers/plugins/views/edit/model.php
@@ -30,10 +30,6 @@ if ($plugin_options_form->isSubmitted()) {
 	// update forms with submitted values
 	$plugin_options_form->setFromSubmit();
 
-	/* CMS::pprint_r ($_POST);
-	CMS::pprint_r ($position_options_form);
-	exit(0); */
-
 	// validate
 	if ($plugin_options_form->validate()) {
 		// forms are valid, save info

--- a/src/admin/controllers/widgets/views/show/model.php
+++ b/src/admin/controllers/widgets/views/show/model.php
@@ -3,11 +3,12 @@
 Use HoltBosse\Alba\Core\{CMS, Template, Content, Widget};
 Use HoltBosse\DB\DB;
 Use HoltBosse\Form\Form;
+Use HoltBosse\Form\Input;
+Use Respect\Validation\Validator as v;
 
 if (sizeof(CMS::Instance()->uri_segments)==3) {
-	$widget_type_id = CMS::Instance()->uri_segments[2];
-}
-else {
+	$widget_type_id = Input::filter(CMS::Instance()->uri_segments[2], v::NumericVal(), false);
+} else {
 	$widget_type_id = false;
 }
 
@@ -48,25 +49,29 @@ if(is_numeric($widget_type_id)) {
 	$params[] = $widget_type_id;
 }
 
-if(isset($_GET["state"]) && is_numeric($_GET["state"])) {
+$searchState = Input::getVar("state", v::numericVal(), null);
+if($searchState) {
 	$query .= " AND w.state=?";
-	$params[] = $_GET["state"];
+	$params[] = $searchState;
 }
 
-if(isset($_GET["title"]) && $_GET["title"]!="") {
+$searchTitle = Input::getVar("title", v::stringType()->length(1, null), null);
+if($searchTitle) {
 	$query .= " AND w.title like ?";
-	$params[] = "%{$_GET['title']}%";
+	$params[] = "%{$searchTitle}%";
 }
 
-if(isset($_GET["widget_type"]) && $_GET["widget_type"]!="") {
+$searchType = Input::getVar("widget_type", v::stringType()->length(1, null), null);
+if($searchType) {
 	$query .= " AND wt.location=?";
-	$params[] = $_GET["widget_type"];
+	$params[] = $searchType;
 }
 
-if(isset($_GET["page"]) && is_numeric($_GET["page"])) {
+$searchPage = Input::getVar("page", v::numericVal(), null);
+if($searchPage) {
 	$query .= " AND ((FIND_IN_SET(?, w.page_list) AND w.position_control=0) OR (NOT FIND_IN_SET(?, w.page_list) AND w.position_control=1))";
-	$params[] = $_GET["page"];
-	$params[] = $_GET["page"];
+	$params[] = $searchPage;
+	$params[] = $searchPage;
 }
 
 $query .= ' ORDER BY id DESC';

--- a/src/corecontrollers/api/controller.php
+++ b/src/corecontrollers/api/controller.php
@@ -21,7 +21,7 @@ if(sizeof($segments)==2 && $segments[1]=="parsedown") {
         echo json_encode($response);
     }
 
-    if(isset($_GET["markup"])) {
+    if(Input::getVar("markup", v::StringVal(), null)) {
 
         /* $markup = '
         Welcome to the demo:


### PR DESCRIPTION
does what it says on the tin

in this pr focused on all our raw get and post superglobal access (aka being bad), and swaps them to using input::getvar and type filtering