### PR TITLE
Better validation

### DIFF
--- a/src/Core/CMS.php
+++ b/src/Core/CMS.php
@@ -5,6 +5,7 @@ Use HoltBosse\DB\DB;
 Use HoltBosse\Form\Input;
 Use HoltBosse\Form\Form;
 Use HoltBosse\Form\Fields\{Antispam, Checkbox, Honeypot, Html, Input as Text, Select, Textarea};
+Use Respect\Validation\Validator as v;
 Use \stdClass;
 Use \Exception;
 
@@ -660,7 +661,7 @@ final class CMS {
 		// if ADMIN but guest, show login
 
 		if ( ($this->isAdmin() && $this->user->username=="guest") || ($this->user->username=="guest" && $_ENV["frontendlogin"]==="true") ) {
-			$email = Input::getvar('email','EMAIL'); // note: php email filter is a bit more picky than html input type email
+			$email = Input::getvar('email',v::email()); // note: php email filter is a bit more picky than html input type email
         	$password = Input::getvar('password','RAW');
 			
 			$loginResult = Access::handleLogin($email, $password);

--- a/src/Core/Page.php
+++ b/src/Core/Page.php
@@ -4,6 +4,7 @@ namespace HoltBosse\Alba\Core;
 Use HoltBosse\DB\DB;
 Use HoltBosse\Form\{Form, Input};
 Use \PDOException;
+Use Respect\Validation\Validator as v;
 
 class Page {
 	public $id;
@@ -128,19 +129,19 @@ class Page {
 	}
 
 	public function load_from_post() {
-		$this->title = Input::getvar('title');
-		$this->state = Input::getvar('state','NUM', 1);
-		$this->template_id = Input::getvar('template','NUM');
-		$this->alias = Input::getvar('alias','TEXT');
+		$this->title = Input::getvar('title', v::StringVal());
+		$this->state = Input::getvar('state',v::IntVal(), 1);
+		$this->template_id = Input::getvar('template',v::IntVal());
+		$this->alias = Input::getvar('alias',v::StringVal());
 		if (!$this->alias) {
 			$this->alias = Input::stringURLSafe($this->title);
 		}
-		$this->parent = Input::getvar('parent','NUM');
-		$this->content_type = Input::getvar('content_type','NUM');
-		$this->view = Input::getvar('content_type_controller_view','NUM');
+		$this->parent = Input::getvar('parent',v::IntVal());
+		$this->content_type = Input::getvar('content_type',v::IntVal());
+		$this->view = Input::getvar('content_type_controller_view',v::IntVal());
 
 		// OLD: view_options now handles by options_form.json in view
-		$this->view_configuration = Input::getvar('view_options','ARRAYTOJSON');
+		$this->view_configuration = json_encode(Input::getvar('view_options',v::arrayType()));
 		// TODO: load from options_form
 		// e.g. $options_form = new Form(form location);
 		// $options_form->setFromSubmit();
@@ -148,7 +149,7 @@ class Page {
 		// jsonify
 		// save as $this->view_configuration
 		
-		$this->id = Input::getvar('id','NUM');
+		$this->id = Input::getvar('id',v::IntVal());
 
 		$this->domain = Input::getvar("domain", "RAW");
 

--- a/src/Core/User.php
+++ b/src/Core/User.php
@@ -114,16 +114,16 @@ class User {
 		else {
 			$this->password = null;
 		}
-		$this->email = Input::getvar('email','EMAIL');
+		$this->email = Input::getvar('email',v::email());
 		if (!$this->email) {
 			CMS::Instance()->queue_message('Invalid email','warning');
 			return false;
 		}
 		$this->registered = date('Y-m-d H:i:s');
-		$this->id = Input::getvar('id','INT');
-		$this->groups = Input::getvar('groups','ARRAYOFINT');
-		$this->tags = Input::getvar('tags','ARRAYOFINT');
-		$this->state = Input::getvar('userstate','INT');
+		$this->id = Input::getvar('id',v::IntVal(),null);
+		$this->groups = Input::getvar('groups',v::arrayType()->each(v::intVal()));
+		$this->tags = Input::getvar('tags',v::arrayType()->each(v::intVal()));
+		$this->state = Input::getvar('userstate',v::IntVal());
 		return true;
 	}
 

--- a/src/Core/Widget.php
+++ b/src/Core/Widget.php
@@ -5,6 +5,7 @@ Use HoltBosse\DB\DB;
 Use HoltBosse\Alba\Core\{Hook, JSON};
 Use HoltBosse\Form\{Form, Input};
 Use \stdClass;
+Use Respect\Validation\Validator as v;
 
 class Widget {
 	public $id;
@@ -201,8 +202,8 @@ class Widget {
 	public function save($required_details_form, $widget_options_form, $position_options_form) {
 		// update this object with submitted and validated form info
 		$redirect_url = $_ENV["uripath"] . '/admin/widgets/show';
-		if (Input::getvar("http_referer_form") && Input::getvar("http_referer_form") != $_SERVER["HTTP_REFERER"]){
-			$redirect_url = Input::getvar("http_referer_form");
+		if (Input::getvar("http_referer_form", v::StringVal()) && Input::getvar("http_referer_form", v::StringVal()) != $_SERVER["HTTP_REFERER"]){
+			$redirect_url = Input::getvar("http_referer_form", v::StringVal());
 		}
 		$this->title = $required_details_form->getFieldByName('title')->default;
 		$this->state = $required_details_form->getFieldByName('state')->default;

--- a/src/Fields/PageSelector/PageSelector.php
+++ b/src/Fields/PageSelector/PageSelector.php
@@ -3,6 +3,7 @@ namespace HoltBosse\Alba\Fields\PageSelector;
 
 Use HoltBosse\Form\{Field, Input};
 Use HoltBosse\Alba\Core\{CMS, Page};
+Use Respect\Validation\Validator as v;
 
 class PageSelector extends Field {
 
@@ -84,7 +85,7 @@ class PageSelector extends Field {
 	public function loadFromConfig($config) {
 		parent::loadFromConfig($config);
 		
-		$this->filter = $config->filter ?? 'ARRAYOFINT';
+		$this->filter = $config->filter ?? v::arrayType()->each(v::intVal());
 		$this->multiple = $config->multiple ?? true;
 	}
 

--- a/src/Plugins/GoogleLoginJwt/GoogleLoginJwt.php
+++ b/src/Plugins/GoogleLoginJwt/GoogleLoginJwt.php
@@ -47,7 +47,7 @@ class GoogleLoginJwt extends Plugin {
             return $user_object;
         }
 
-        $jwt_credentials = Input::getvar('credential');
+        $jwt_credentials = Input::getvar('credential', "RAW");
         
         if (!$jwt_credentials) {
             // google login not attempted
@@ -55,7 +55,7 @@ class GoogleLoginJwt extends Plugin {
         }
 
         // double-cookie CSRF mitigation check
-        $csrf_token_body = Input::getvar('g_csrf_token');
+        $csrf_token_body = Input::getvar('g_csrf_token', "RAW");
         $csrf_token_cookie = $_COOKIE['g_csrf_token'];
         if (!$csrf_token_body || !$csrf_token_cookie || ($csrf_token_body!=$csrf_token_cookie)) {
             CMS::Instance()->queue_message('CSRF verification check failed','danger', $_ENV["uripath"] . "/admin");

--- a/src/Plugins/UserVerify/UserVerify.php
+++ b/src/Plugins/UserVerify/UserVerify.php
@@ -4,6 +4,7 @@ namespace HoltBosse\Alba\Plugins\UserVerify;
 Use HoltBosse\Alba\Core\{CMS, Plugin, Mail, User, Configuration};
 Use HoltBosse\Form\{Input};
 Use HoltBosse\DB\DB;
+Use Respect\Validation\Validator as v;
 
 class UserVerify extends Plugin {
 
@@ -96,9 +97,9 @@ class UserVerify extends Plugin {
     public function user_verification() {
         if(!$_GET) {
             //we want details via post
-            $username = Input::getvar("username", "TEXT");
-            $email = Input::getvar("email", "TEXT");
-            $password1 = Input::getvar("password1", "TEXT");
+            $username = Input::getvar("username", v::StringVal(), '');
+            $email = Input::getvar("email", v::StringVal(), '');
+            $password1 = Input::getvar("password1", v::StringVal(), '');
             //perhaps consider optional server side two password field verification?
 
             if($username && $email && $password1 && !DB::fetch("SELECT * FROM users WHERE email=?", $email)) {
@@ -118,10 +119,10 @@ class UserVerify extends Plugin {
 
             $this->make_message($message);
         } else {
-            if(Input::getvar("key", "TEXT")) {
+            if(Input::getvar("key", v::StringVal(), '')) {
                 //get verification key here and validate account
                 $user = new User();
-                $user->get_user_by_reset_key(Input::getvar("key", "TEXT"));
+                $user->get_user_by_reset_key(Input::getvar("key", v::StringVal(), ''));
                 if($user->id) {
                     DB::exec("UPDATE users SET state=1 WHERE id=?", $user->id); //enable the user
                     $user->remove_reset_key();

--- a/src/Widgets/Menu/Menu.php
+++ b/src/Widgets/Menu/Menu.php
@@ -5,6 +5,7 @@ Use HoltBosse\Alba\Core\{CMS, Widget, Page, Content};
 Use HoltBosse\Form\Input;
 Use HoltBosse\DB\DB;
 Use \stdClass;
+Use Respect\Validation\Validator as v;
 
 class Menu extends Widget {
 
@@ -14,7 +15,7 @@ class Menu extends Widget {
 	}
 
 	public function custom_save() {
-		$menu_designer_config_json = Input::getvar('menu_designer_config','STRING');
+		$menu_designer_config_json = Input::getvar('menu_designer_config',v::StringVal(),'');
 		$obj = new stdClass();
 		$obj->name = "menu_designer_config";
 		$obj->value = $menu_designer_config_json;

--- a/src/admin/controllers/categories/views/action/model.php
+++ b/src/admin/controllers/categories/views/action/model.php
@@ -3,13 +3,14 @@
 Use HoltBosse\Alba\Core\{CMS, Actions};
 Use HoltBosse\DB\DB;
 Use HoltBosse\Form\Input;
+Use Respect\Validation\Validator as v;
 
 $action = CMS::Instance()->uri_segments[2];
 if (!$action) {
 	CMS::Instance()->queue_message('Unknown action','danger', $_SERVER['HTTP_REFERER']);
 }
 
-$id = Input::getvar('id','ARRAYOFINT');
+$id = Input::getvar('id',v::arrayType()->each(v::intVal()));
 if (!$id) {
 	CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
 }

--- a/src/admin/controllers/categories/views/all/model.php
+++ b/src/admin/controllers/categories/views/all/model.php
@@ -3,9 +3,10 @@
 Use HoltBosse\Alba\Core\{CMS, Category, Content};
 Use HoltBosse\DB\DB;
 Use HoltBosse\Form\Input;
+Use Respect\Validation\Validator as v;
 
 $segments = CMS::Instance()->uri_segments;
-$search = Input::getvar('search','TEXT',null);
+$search = Input::getvar('search',v::StringVal(),null);
 
 $content_type_filter = 0;
 if (sizeof($segments)==3) {

--- a/src/admin/controllers/categories/views/all/view.php
+++ b/src/admin/controllers/categories/views/all/view.php
@@ -45,7 +45,7 @@
 
 	<div class="field has-addons">
 		<div class="control">
-			<input value="<?php echo $search; ?>" name="search" form="searchform" class="input" type="text" placeholder="Search title/note">
+			<input value="<?php echo Input::stringHtmlSafe($search); ?>" name="search" form="searchform" class="input" type="text" placeholder="Search title/note">
 		</div>
 		<div class="control">
 			<button form="searchform" type="submit" class="button is-info">

--- a/src/admin/controllers/content/views/action/model.php
+++ b/src/admin/controllers/content/views/action/model.php
@@ -3,13 +3,14 @@
 Use HoltBosse\Alba\Core\{CMS, Content, Actions, JSON};
 Use HoltBosse\DB\DB;
 Use HoltBosse\Form\Input;
+Use Respect\Validation\Validator as v;
 
 $action = CMS::Instance()->uri_segments[2];
 if (!$action) {
 	CMS::Instance()->queue_message('Unknown action','danger', $_SERVER['HTTP_REFERER']);
 }
 
-$content_type = Input::getvar('content_type','INT',null);
+$content_type = Input::getvar('content_type',v::IntVal(),null);
 if (!$content_type) {
 	CMS::Instance()->queue_message('Unknown content type','danger', $_SERVER['HTTP_REFERER']);
 }
@@ -24,7 +25,7 @@ if ($table_name=="controller_") {
 
 
 if ($action=='toggle') {
-	$id = Input::getvar('id','ARRAYOFINT');
+	$id = Input::getvar('id',v::arrayType()->each(v::intVal()));
 	if (!$id) {
 		CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
 	}
@@ -59,7 +60,7 @@ if ($action=='toggle') {
 }
 
 if ($action=='togglestate') {
-	$togglestate = Input::getvar('togglestate','ARRAYOFINT');
+	$togglestate = Input::getvar('togglestate',v::arrayType()->each(v::intVal()));
 	if (!$togglestate) {
 		CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
 	}
@@ -90,7 +91,7 @@ if ($action=='togglestate') {
 }
 
 elseif ($action=='publish') {
-	$id = Input::getvar('id','ARRAYOFINT');
+	$id = Input::getvar('id',v::arrayType()->each(v::intVal()));
 	if (!$id) {
 		CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
 	}
@@ -124,7 +125,7 @@ elseif ($action=='publish') {
 }
 
 elseif ($action=='unpublish') {
-	$id = Input::getvar('id','ARRAYOFINT');
+	$id = Input::getvar('id',v::arrayType()->each(v::intVal()));
 	if (!$id) {
 		CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
 	}
@@ -158,7 +159,7 @@ elseif ($action=='unpublish') {
 }
 
 elseif ($action=='delete') {
-	$id = Input::getvar('id','ARRAYOFINT');
+	$id = Input::getvar('id',v::arrayType()->each(v::intVal()));
 	if (!$id) {
 		CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
 	}
@@ -192,7 +193,7 @@ elseif ($action=='delete') {
 }
 
 elseif ($action=='duplicate') {
-	$ids = Input::getvar('id','ARRAYOFINT');
+	$ids = Input::getvar('id',v::arrayType()->each(v::intVal()));
 	if (!$ids) {
 		//CMS::pprint_r ($ids);exit(0);
 		CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
@@ -200,7 +201,7 @@ elseif ($action=='duplicate') {
 	
 	foreach ($ids as $id) {
 		$orig = new Content();
-		$orig->load($id, Input::getvar('content_type','INT'));
+		$orig->load($id, Input::getvar('content_type',v::IntVal()));
 		$orig->duplicate();
 	}
 	// todo: nicely report on good or bad duplicates

--- a/src/admin/controllers/content/views/all/model.php
+++ b/src/admin/controllers/content/views/all/model.php
@@ -9,7 +9,7 @@ $segments = CMS::Instance()->uri_segments;
 $search = Input::getvar('search','RAW',null);
 $filters = Input::tuplesToAssoc( Input::getvar('filters','RAW',null) );
 // make sure coretags getvar returns empty array PHP 8+ in_array required haystack to be array
-$coretags = Input::getvar('coretags','ARRAYOFINT',[]);
+$coretags = Input::getvar('coretags',v::arrayType()->each(v::intVal()),[]);
 
 $content_type_filter = null;
 if (sizeof($segments)>3) {
@@ -25,7 +25,7 @@ if(!$contentTypeTableRecord) {
 	CMS::raise_404();
 }
 
-$cur_page = Input::getvar('page','INT','1');
+$cur_page = Input::getvar('page',v::IntVal(),'1');
 
 $all_content_types = Content::get_all_content_types();
 $pagination_size = Configuration::get_configuration_value ('general_options', 'pagination_size');

--- a/src/admin/controllers/content/views/api/model.php
+++ b/src/admin/controllers/content/views/api/model.php
@@ -3,6 +3,7 @@
 Use HoltBosse\Alba\Core\{CMS, Content};
 Use HoltBosse\Form\Input;
 Use HoltBosse\DB\DB;
+Use Respect\Validation\Validator as v;
 
 ob_end_clean(); // IMPORTANT - empty output buffer from template to ensure on JSON is returned
 ob_end_clean();
@@ -16,10 +17,10 @@ $action = Input::getvar('action','STRING');
 
 if ($action=="changeorder") {
 	// id, new_order, prev_order, content_type
-	$id = Input::getvar('id','NUMBER');
-	$new_order = Input::getvar('new_order','INT');
-	$prev_order = Input::getvar('prev_order','INT');
-	$content_type = Input::getvar('content_type','INT');
+	$id = Input::getvar('id',v::IntVal());
+	$new_order = Input::getvar('new_order',v::IntVal());
+	$prev_order = Input::getvar('prev_order',v::IntVal());
+	$content_type = Input::getvar('content_type',v::IntVal());
 	if (!$id || !$new_order || !$prev_order || !$content_type) {
 		rj([
 			"success"=>0,

--- a/src/admin/controllers/content/views/edit/model.php
+++ b/src/admin/controllers/content/views/edit/model.php
@@ -123,7 +123,7 @@ if ($required_details_form->isSubmitted()) {
 	if ($required_details_form->validate() && $content_form->validate()) {
 		// forms are valid, save info
 
-		$quicksave = Input::getvar('quicksave',"STRING");
+		$quicksave = Input::getvar('quicksave',V::StringVal());
 		$saved = $content->save($required_details_form, $content_form );
 	
 		if ($saved) {
@@ -133,7 +133,7 @@ if ($required_details_form->isSubmitted()) {
 			}
 			else {
 				$redirect_to = $_ENV["uripath"] . "/admin/content/all/" . $content->content_type;
-				if (Input::getvar("http_referer_form") && Input::getvar("http_referer_form") != $_SERVER["HTTP_REFERER"]){
+				if (Input::getvar("http_referer_form", v::StringVal()) && Input::getvar("http_referer_form", v::StringVal()) != $_SERVER["HTTP_REFERER"]){
 					$redirect_to = Input::getvar("http_referer_form");
 				}
 				$msg = "Content <a href='" . $_ENV["uripath"] . "/admin/content/edit/{$content->id}/{$content_type}'>" . Input::stringHtmlSafe($content->title) . "</a> " . ($new_content ? 'created' : 'updated');

--- a/src/admin/controllers/forms/views/action/model.php
+++ b/src/admin/controllers/forms/views/action/model.php
@@ -3,6 +3,7 @@
 Use HoltBosse\Alba\Core\{CMS, Configuration};
 Use HoltBosse\Form\Input;
 Use HoltBosse\DB\DB;
+Use Respect\Validation\Validator as v;
 
 $table_name = "form_instances";
 $action = CMS::Instance()->uri_segments[2];
@@ -12,7 +13,7 @@ if (!$action) {
 }
 
 if ($action=='toggle') {
-	$id = Input::getvar('id','ARRAYOFINT');
+	$id = Input::getvar('id',v::arrayType()->each(v::intVal()));
 	if (!$id) {
 		CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
 	}
@@ -28,7 +29,7 @@ if ($action=='toggle') {
 }
 
 if ($action=='togglestate') {
-	$togglestate = Input::getvar('togglestate','ARRAYOFINT');
+	$togglestate = Input::getvar('togglestate',v::arrayType()->each(v::intVal()));
 	if (!$togglestate) {
 		CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
 	}
@@ -42,7 +43,7 @@ if ($action=='togglestate') {
 }
 
 elseif ($action=='publish') {
-	$id = Input::getvar('id','ARRAYOFINT');
+	$id = Input::getvar('id',v::arrayType()->each(v::intVal()));
 	if (!$id) {
 		CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
 	}
@@ -57,7 +58,7 @@ elseif ($action=='publish') {
 }
 
 elseif ($action=='unpublish') {
-	$id = Input::getvar('id','ARRAYOFINT');
+	$id = Input::getvar('id',v::arrayType()->each(v::intVal()));
 	if (!$id) {
 		CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
 	}
@@ -72,7 +73,7 @@ elseif ($action=='unpublish') {
 }
 
 elseif ($action=='delete') {
-	$id = Input::getvar('id','ARRAYOFINT');
+	$id = Input::getvar('id',v::arrayType()->each(v::intVal()));
 	if (!$id) {
 		CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
 	}

--- a/src/admin/controllers/forms/views/submissions/model.php
+++ b/src/admin/controllers/forms/views/submissions/model.php
@@ -12,7 +12,7 @@ if(sizeof($segments) > 2) {
 
 $paginationSize = Configuration::get_configuration_value ('general_options', 'pagination_size');
 
-$curPage = Input::getvar('page','INT','1');
+$curPage = Input::getvar('page',v::IntVal(),'1');
 
 $formSelectOptions = DB::fetchAll("SELECT DISTINCT form_id AS value, form_path FROM form_submissions");
 $formSelectOptions = array_map(function($input) {

--- a/src/admin/controllers/images/views/api/model.php
+++ b/src/admin/controllers/images/views/api/model.php
@@ -3,6 +3,7 @@
 Use HoltBosse\Alba\Core\{CMS, Actions, File};
 Use HoltBosse\Form\Input;
 Use HoltBosse\DB\DB;
+Use Respect\Validation\Validator as v;
 
 ob_end_clean(); // IMPORTANT - empty output buffer from template to ensure on JSON is returned
 ob_end_clean(); // do it again, we may be inside another buffer due to reasons
@@ -11,14 +12,14 @@ ob_end_clean(); // do it again, we may be inside another buffer due to reasons
 
 // TODO: remove front-end images api model????
 
-$action = Input::getvar('action','STRING');
-$mimetypes = array_filter(explode(',',Input::getvar('mimetypes','STRING'))); // array_filter ensures empty array if mimetypes is null
+$action = Input::getvar('action',v::StringVal());
+$mimetypes = array_filter(explode(',',Input::getvar('mimetypes',v::StringVal(),''))); // array_filter ensures empty array if mimetypes is null
 // TODO sanitize mimetypes against whitelist
 
 if ($action=='tag_media') {
-	$image_ids_string = Input::getvar('id_list','STRING');
+	$image_ids_string = Input::getvar('id_list',v::StringVal(),'');
 	$image_ids = explode(",", $image_ids_string);
-	$tag_id = Input::getvar('tag_id',"INT");
+	$tag_id = Input::getvar('tag_id',v::IntVal());
 	$image_ids_tagged=[];
 	$image_ids_failed=[];
 	foreach ($image_ids as $image_id) {
@@ -46,7 +47,7 @@ if ($action=='tag_media') {
 }
 
 if ($action=='cleartags_media') {
-	$image_ids_string = Input::getvar('id_list','STRING');
+	$image_ids_string = Input::getvar('id_list',v::StringVal(),'');
 	$image_ids = explode(",", $image_ids_string);
 	$image_ids_tagged=[];
 	$image_ids_failed=[];
@@ -67,7 +68,7 @@ if ($action=='cleartags_media') {
 }
 
 if ($action=='delete_media') {
-	$image_ids_string = Input::getvar('id_list','STRING');
+	$image_ids_string = Input::getvar('id_list',v::StringVal(),'');
 	$image_ids = explode(",", $image_ids_string);
 	$image_ids_tagged=[];
 	$image_ids_failed=[];
@@ -103,11 +104,11 @@ if ($action=='delete_media') {
 
 if ($action=='untag_media') {
 	// clear single tag from media list
-	$image_ids_string = Input::getvar('id_list','STRING');
+	$image_ids_string = Input::getvar('id_list',v::StringVal(),'');
 	$image_ids = explode(",", $image_ids_string);
 	$image_ids_untagged=[];
 	$image_ids_failed=[];
-	$tag_id = Input::getvar('tag_id','NUM');
+	$tag_id = Input::getvar('tag_id',v::IntVal());
 	foreach ($image_ids as $image_id) {
 		Actions::add_action("mediaupdate", (object) [
 			"affected_media"=>$image_id,
@@ -177,9 +178,9 @@ if ($action=='delete') {
 }
 
 if ($action=='rename_image') {
-	$title = Input::getvar('title','STRING');
-	$alt = Input::getvar('alt','STRING');
-	$image_id = Input::getvar('image_id','NUM');
+	$title = Input::getvar('title',v::StringVal(),'');
+	$alt = Input::getvar('alt',v::StringVal(),'');
+	$image_id = Input::getvar('image_id',v::IntVal());
 
 	Actions::add_action("mediaupdate", (object) [
 		"affected_media"=>$image_id,

--- a/src/admin/controllers/images/views/show/model.php
+++ b/src/admin/controllers/images/views/show/model.php
@@ -3,6 +3,7 @@
 Use HoltBosse\Alba\Core\{CMS, Configuration, Content, File};
 Use HoltBosse\DB\DB;
 Use HoltBosse\Form\Input;
+Use Respect\Validation\Validator as v;
 
 $segments = CMS::Instance()->uri_segments;
 if(sizeof($segments)>2) {
@@ -15,9 +16,9 @@ foreach(File::$image_types as $type => $value) {
 }
 
 $pagination_size = Configuration::get_configuration_value ('general_options', 'pagination_size');
-$cur_page = Input::getvar('page','INT','1');
+$cur_page = Input::getvar('page',v::IntVal(),'1');
 
-$searchtext = Input::getvar('searchtext','TEXT',null);
+$searchtext = Input::getvar('searchtext',v::StringVal(),null);
 
 $query = "FROM media WHERE mimetype IN (" . implode(",", $valid_image_types) . ") ";
 $params = [];
@@ -31,8 +32,8 @@ $images_count = DB::fetch("SELECT count(*) as count " . $query, $params)->count;
 
 $image_tags = Content::get_applicable_tags(-1);
 
-$filter = Input::getvar('filter','STRING');
-$autoclose = Input::getvar('autoclose','STRING');
+$filter = Input::getvar('filter',v::StringVal(),'');
+$autoclose = Input::getvar('autoclose',v::StringVal(),'');
 
 $max_upload_size = File::get_max_upload_size();
 $max_upload_size_bytes = File::get_max_upload_size_bytes();

--- a/src/admin/controllers/images/views/show/view.php
+++ b/src/admin/controllers/images/views/show/view.php
@@ -28,7 +28,7 @@ Use HoltBosse\Form\Input;
 			<div class="field">
 				<label class="label">Search Title/Alt/Filename</label>
 				<div class="control">
-					<input value="<?=$searchtext?>" name="searchtext" form="searchform" class="input" type="text" placeholder="">
+					<input value="<?=input::StringHtmlSafe($searchtext)?>" name="searchtext" form="searchform" class="input" type="text" placeholder="">
 				</div>
 			</div>
 			<div class="field">

--- a/src/admin/controllers/images/views/uploadv2/model.php
+++ b/src/admin/controllers/images/views/uploadv2/model.php
@@ -3,6 +3,7 @@
 Use HoltBosse\Alba\Core\{CMS, File, Actions};
 Use HoltBosse\Form\Input;
 Use HoltBosse\DB\DB;
+Use Respect\Validation\Validator as v;
 
 ob_end_clean(); // IMPORTANT - empty output buffer from template to ensure on JSON is returned
 ob_end_clean(); // IMPORTANT - empty output buffer from template to ensure on JSON is returned
@@ -21,10 +22,10 @@ header('Content-Type: application/json; charset=utf-8');
 $image_types_data = File::$image_types;
 
 $uploaded_files_array = $_FILES['file-upload'];
-$alts = Input::getvar('alt','ARRAYOFSTRING');
-$titles = Input::getvar('title','ARRAYOFSTRING');
-$tags = Input::getvar('tags','ARRAYOFSTRING');
-$web_friendly_array = Input::getvar('web_friendly','ARRAYOFINT');
+$alts = Input::getvar('alt',v::arrayType()->each(v::StringVal()));
+$titles = Input::getvar('title',v::arrayType()->each(v::StringVal()));
+$tags = Input::getvar('tags',v::arrayType()->each(v::StringVal()));
+$web_friendly_array = Input::getvar('web_friendly',v::arrayType()->each(v::intVal()));
 $directory = $_ENV["images_directory"] . '/processed';
 $uploaded_files = [];
 

--- a/src/admin/controllers/pages/views/action/model.php
+++ b/src/admin/controllers/pages/views/action/model.php
@@ -3,6 +3,7 @@
 Use HoltBosse\Alba\Core\{CMS, Actions};
 Use HoltBosse\DB\DB;
 Use HoltBosse\Form\Input;
+Use Respect\Validation\Validator as v;
 
 
 $action = CMS::Instance()->uri_segments[2];
@@ -11,7 +12,7 @@ if (!$action) {
 }
 
 
-$id = Input::getvar('id','ARRAYOFINT');
+$id = Input::getvar('id',v::arrayType()->each(v::intVal()));
 if (!$id) {
 	CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
 }

--- a/src/admin/controllers/pages/views/save/model.php
+++ b/src/admin/controllers/pages/views/save/model.php
@@ -15,7 +15,7 @@ if (!$success) {
 	CMS::Instance()->queue_message('Failed to create page object from form data','danger',$_ENV["uripath"].'/admin/pages');
 }
 
-if(Input::getvar("id")==0) {
+if(Input::getvar("id",v::IntVal())==0) {
 	$new_page = true;
 	$existing_page = DB::fetch("SELECT * FROM pages WHERE alias=? AND parent=? AND domain=?", [$page->alias, $page->parent, $page->domain]);
 	if($existing_page) {
@@ -26,9 +26,9 @@ if(Input::getvar("id")==0) {
 	}
 }
 
-if(Input::getvar("id")!=0) {
+if(Input::getvar("id",v::IntVal())!=0) {
 	$existingPage = new Page();
-	$existingPage->load_from_id(Input::getvar("id"));
+	$existingPage->load_from_id(Input::getvar("id",v::IntVal()));
 
 	if($existingPage->domain!=$page->domain) {
 		$aliasAlreadyExistForDomain = DB::fetch("SELECT * FROM pages WHERE alias=? AND domain=?", [$page->alias, $page->domain]);
@@ -91,7 +91,7 @@ if ($success) {
 		$override_success = DB::exec("insert into page_widget_overrides (page_id, position, widgets) values (?,?,?) on duplicate key update page_id=?, position=?, widgets=?", $data);
 	}
 
-	$quicksave = Input::getvar('quicksave',"STRING");
+	$quicksave = Input::getvar('quicksave',v::StringVal(),'');
 	if ($quicksave) {
 		$msg = "Quicksave successful";
 		$redirectTo = $_SERVER['HTTP_REFERER'];

--- a/src/admin/controllers/plugins/views/action/model.php
+++ b/src/admin/controllers/plugins/views/action/model.php
@@ -3,6 +3,7 @@
 Use HoltBosse\Alba\Core\{CMS, Plugin};
 Use HoltBosse\DB\DB;
 Use HoltBosse\Form\{Form, Input};
+Use Respect\Validation\Validator as v;
 
 
 $action = CMS::Instance()->uri_segments[2];
@@ -10,7 +11,7 @@ if (!$action) {
 	CMS::Instance()->queue_message('Unknown action','danger', $_SERVER['HTTP_REFERER']);
 }
 
-$id = Input::getvar('id','ARRAYOFINT');
+$id = Input::getvar('id',v::arrayType()->each(v::intVal()));
 if (!$id) {
 	CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
 }

--- a/src/admin/controllers/redirects/views/action/model.php
+++ b/src/admin/controllers/redirects/views/action/model.php
@@ -3,6 +3,7 @@
 Use HoltBosse\Alba\Core\{CMS, Configuration};
 Use HoltBosse\Form\Input;
 Use HoltBosse\DB\DB;
+Use Respect\Validation\Validator as v;
 
 $table_name = "redirects";
 $action = CMS::Instance()->uri_segments[2];
@@ -12,7 +13,7 @@ if (!$action) {
 }
 
 if ($action=='toggle') {
-	$id = Input::getvar('id','ARRAYOFINT');
+	$id = Input::getvar('id',v::arrayType()->each(v::intVal()));
 	if (!$id) {
 		CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
 	}
@@ -28,7 +29,7 @@ if ($action=='toggle') {
 }
 
 if ($action=='togglestate') {
-	$togglestate = Input::getvar('togglestate','ARRAYOFINT');
+	$togglestate = Input::getvar('togglestate',v::arrayType()->each(v::intVal()));
 	if (!$togglestate) {
 		CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
 	}
@@ -42,7 +43,7 @@ if ($action=='togglestate') {
 }
 
 elseif ($action=='publish') {
-	$id = Input::getvar('id','ARRAYOFINT');
+	$id = Input::getvar('id',v::arrayType()->each(v::intVal()));
 	if (!$id) {
 		CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
 	}
@@ -57,7 +58,7 @@ elseif ($action=='publish') {
 }
 
 elseif ($action=='unpublish') {
-	$id = Input::getvar('id','ARRAYOFINT');
+	$id = Input::getvar('id',v::arrayType()->each(v::intVal()));
 	if (!$id) {
 		CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
 	}
@@ -72,7 +73,7 @@ elseif ($action=='unpublish') {
 }
 
 elseif ($action=='delete') {
-	$id = Input::getvar('id','ARRAYOFINT');
+	$id = Input::getvar('id',v::arrayType()->each(v::intVal()));
 	if (!$id) {
 		CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
 	}

--- a/src/admin/controllers/redirects/views/all/model.php
+++ b/src/admin/controllers/redirects/views/all/model.php
@@ -3,15 +3,16 @@
 Use HoltBosse\Alba\Core\{CMS, Configuration};
 Use HoltBosse\Form\Input;
 Use HoltBosse\DB\DB;
+Use Respect\Validation\Validator as v;
 
 // any variables created here will be available to the view
 
 $segments = CMS::Instance()->uri_segments;
-$search = Input::getvar('search','TEXT',null);
+$search = Input::getvar('search',v::StringVal(),null);
 $filters = Input::tuplesToAssoc( Input::getvar('filters','RAW',null) );
-$cur_page = Input::getvar('page','INT','1');
+$cur_page = Input::getvar('page',v::IntVal(),'1');
 $page_size = Configuration::get_configuration_value ('general_options', 'pagination_size'); 
-$order_by = Input::getvar('order_by','STRING');
+$order_by = Input::getvar('order_by',v::StringVal(),'');
 $order_by_snippet = " ORDER BY created DESC ";
 if ($order_by && $order_by=="hits") {
     $order_by_snippet = " ORDER BY hits DESC ";

--- a/src/admin/controllers/redirects/views/all/view.php
+++ b/src/admin/controllers/redirects/views/all/view.php
@@ -22,7 +22,7 @@ Use HoltBosse\DB\DB;
 		<div class="field">
 			<label class="label">Search URL/Note</label>
 			<div class="control">
-				<input value="<?php echo $search; ?>" name="search" form="searchform" class="input" type="text" placeholder="">
+				<input value="<?php echo Input::StringHtmlSafe($search); ?>" name="search" form="searchform" class="input" type="text" placeholder="">
 			</div>
 		</div>
 

--- a/src/admin/controllers/settings/views/backups/model.php
+++ b/src/admin/controllers/settings/views/backups/model.php
@@ -36,7 +36,7 @@ if ($submitted) {
 	if (!function_exists('exec')) {
 		CMS::Instance()->queue_message('Error creating backup - exec not available','danger',$_ENV["uripath"]."/admin");
 	}
-	if (!`which mysqldump`) {
+	if (!shell_exec("which mysqldump")) {
 		CMS::Instance()->queue_message('Error creating backup - mysqldump not available','danger',$_ENV["uripath"]."/admin");
 	}
 	if (!class_exists('ZipArchive',false)) {

--- a/src/admin/controllers/tags/views/action/model.php
+++ b/src/admin/controllers/tags/views/action/model.php
@@ -3,6 +3,7 @@
 Use HoltBosse\Alba\Core\{CMS, Actions};
 Use HoltBosse\DB\DB;
 Use HoltBosse\Form\Input;
+Use Respect\Validation\Validator as v;
 
 $action = CMS::Instance()->uri_segments[2];
 if (!$action) {
@@ -10,7 +11,7 @@ if (!$action) {
 }
 
 if ($action=='togglestate') {
-	$togglestate = Input::getvar('togglestate','ARRAYOFINT');
+	$togglestate = Input::getvar('togglestate',v::arrayType()->each(v::intVal()));
 	if (!$togglestate) {
 		CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
 	}
@@ -28,7 +29,7 @@ if ($action=='togglestate') {
 	}
 }
 
-$id = Input::getvar('id','ARRAYOFINT');
+$id = Input::getvar('id',v::arrayType()->each(v::intVal()));
 if (!$id) {
 	CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
 }

--- a/src/admin/controllers/tags/views/show/model.php
+++ b/src/admin/controllers/tags/views/show/model.php
@@ -2,9 +2,10 @@
 
 Use HoltBosse\Alba\Core\Tag;
 Use HoltBosse\Form\Input;
+Use Respect\Validation\Validator as v;
 
 //$all_tags = Tag::get_all_tags();
 
 $all_tags = Tag::get_all_tags_by_depth();
-$search = Input::getvar('search','STRING',null);
+$search = Input::getvar('search',v::StringVal(),null);
 

--- a/src/admin/controllers/tags/views/show/view.php
+++ b/src/admin/controllers/tags/views/show/view.php
@@ -21,7 +21,7 @@ Use HoltBosse\Form\Input;
 		<div class="field">
 			<label class="label">Search Title/Note</label>
 			<div class="control">
-				<input value="<?php echo $search; ?>" name="search" form="searchform" class="input" type="text" placeholder="">
+				<input value="<?php echo Input::StringHtmlSafe($search); ?>" name="search" form="searchform" class="input" type="text" placeholder="">
 			</div>
 		</div>
 

--- a/src/admin/controllers/users/views/action/model.php
+++ b/src/admin/controllers/users/views/action/model.php
@@ -3,14 +3,15 @@
 Use HoltBosse\Alba\Core\{CMS, User, Actions};
 Use HoltBosse\Form\Input;
 Use HoltBosse\DB\DB;
+Use Respect\Validation\Validator as v;
 
 $action = CMS::Instance()->uri_segments[2];
 if (!$action) {
 	CMS::Instance()->queue_message('Unknown action','danger', $_SERVER['HTTP_REFERER']);
 }
 
-$id = Input::getvar('id','ARRAYOFINT');
-if (!$id && !Input::getvar('togglestate','ARRAYOFINT')) {
+$id = Input::getvar('id',v::arrayType()->each(v::intVal()));
+if (!$id && !Input::getvar('togglestate',v::arrayType()->each(v::intVal()))) {
 	CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
 }
 
@@ -33,7 +34,7 @@ if ($action=='toggle') {
 }
 
 if ($action=='togglestate') {
-	$togglestate = Input::getvar('togglestate','ARRAYOFINT');
+	$togglestate = Input::getvar('togglestate',v::arrayType()->each(v::intVal()));
 	if (!$togglestate) {
 		CMS::Instance()->queue_message('Cannot perform action on unknown users','danger', $_SERVER['HTTP_REFERER']);
 	}

--- a/src/admin/controllers/users/views/default/model.php
+++ b/src/admin/controllers/users/views/default/model.php
@@ -3,6 +3,7 @@
 Use HoltBosse\Alba\Core\{CMS, Configuration, User, UserSearch, Tag};
 Use HoltBosse\Form\Input;
 Use HoltBosse\DB\DB;
+Use Respect\Validation\Validator as v;
 
 // any variables created here will be available to the view
 
@@ -28,11 +29,11 @@ else {
 
 // new user search - based on improved content search
 
-$search = Input::getvar('search','TEXT',null);
+$search = Input::getvar('search',v::StringVal(),null);
 $filters = Input::tuplesToAssoc( Input::getvar('filters','RAW',null) );
-$coretags = Input::getvar('coretags','ARRAYOFINT',[]);
-$groups = Input::getvar('groups','ARRAYOFINT',[]); 
-$cur_page = Input::getvar('page','INT','1');
+$coretags = Input::getvar('coretags',v::arrayType()->each(v::intVal()),[]);
+$groups = Input::getvar('groups',v::arrayType()->each(v::intVal()),[]); 
+$cur_page = Input::getvar('page',v::IntVal(),'1');
 
 $pagination_size = Configuration::get_configuration_value ('general_options', 'pagination_size');
 

--- a/src/admin/controllers/users/views/default/model.php
+++ b/src/admin/controllers/users/views/default/model.php
@@ -86,7 +86,11 @@ if(isset($_ENV["custom_user_fields_file_path"])) {
 	}
 
 	$allUserIds = array_column($all_users, 'id');
-	$cufResults = DB::fetchAll('SELECT * FROM custom_user_fields WHERE user_id IN (' . implode(",", array_map(function($input) {return "?";}, $allUserIds)) . ')', $allUserIds);
+	if(!empty($allUserIds)) {
+		$cufResults = DB::fetchAll('SELECT * FROM custom_user_fields WHERE user_id IN (' . implode(",", array_map(function($input) {return "?";}, $allUserIds)) . ')', $allUserIds);
+	} else {
+		$cufResults = [];
+	}
 	foreach($cufResults as $cufRow) {
 		$customUserFieldsLookup[$cufRow->user_id] = $cufRow;
 	}

--- a/src/admin/controllers/users/views/default/view.php
+++ b/src/admin/controllers/users/views/default/view.php
@@ -40,7 +40,7 @@ Use HoltBosse\Form\Input;
 		<div class="field">
 			<label class="label">Search Name/Email</label>
 			<div class="control">
-				<input value="<?php echo $search; ?>" name="search" form="searchform" class="input" type="text" placeholder="">
+				<input value="<?php echo Input::StringHtmlSafe($search); ?>" name="search" form="searchform" class="input" type="text" placeholder="">
 			</div>
 		</div>
 

--- a/src/admin/controllers/users/views/save/model.php
+++ b/src/admin/controllers/users/views/save/model.php
@@ -3,6 +3,7 @@
 Use HoltBosse\Alba\Core\{CMS, User, Hook};
 Use HoltBosse\Form\{Form, Input};
 Use HoltBosse\DB\DB;
+Use Respect\Validation\Validator as v;
 
 // any variables created here will be available to the view
 
@@ -64,8 +65,8 @@ if ($custom_user_fields_form) {
 }
 
 $redirect_url = $_ENV["uripath"] . '/admin/users';
-if (Input::getvar("http_referer_form") && Input::getvar("http_referer_form") != $_SERVER["HTTP_REFERER"]){
-	$redirect_url = Input::getvar("http_referer_form");
+if (Input::getvar("http_referer_form", v::StringVal()) && Input::getvar("http_referer_form", v::StringVal()) != $_SERVER["HTTP_REFERER"]){
+	$redirect_url = Input::getvar("http_referer_form", v::StringVal());
 }
 
 if ($success) {

--- a/src/admin/controllers/widgets/views/action/model.php
+++ b/src/admin/controllers/widgets/views/action/model.php
@@ -3,13 +3,14 @@
 Use HoltBosse\Alba\Core\{CMS, Component, Hook, Page, Widget};
 Use HoltBosse\Form\Input;
 Use HoltBosse\DB\DB;
+Use Respect\Validation\Validator as v;
 
 $action = CMS::Instance()->uri_segments[2];
 if (!$action) {
 	CMS::Instance()->queue_message('Unknown action','danger', $_SERVER['HTTP_REFERER']);
 }
 
-$id = Input::getvar('id','ARRAYOFINT');
+$id = Input::getvar('id',v::arrayType()->each(v::intVal()));
 if (!$id) {
 	CMS::Instance()->queue_message('Cannot perform action on unknown items','danger', $_SERVER['HTTP_REFERER']);
 }

--- a/src/admin/templates/clean/login.php
+++ b/src/admin/templates/clean/login.php
@@ -3,12 +3,13 @@
 Use HoltBosse\Alba\Core\{CMS, Hook, User, Mail};
 Use HoltBosse\Form\Input;
 Use HoltBosse\DB\DB;
+Use Respect\Validation\Validator as v;
 
-$view = Input::getvar('view','STRING');
+$view = Input::getvar('view',v::StringVal(),'');
 
 // handle reset request
 
-$resetemail = Input::getvar('resetemail','EMAIL');
+$resetemail = Input::getvar('resetemail',v::email());
 if ($resetemail) {
 	$resetUser = new User();
 	$resetUser->load_from_email($resetemail);

--- a/src/controllers/basic_article/views/blog/model.php
+++ b/src/controllers/basic_article/views/blog/model.php
@@ -3,6 +3,7 @@
 Use HoltBosse\Alba\Core\{CMS, Content};
 Use HoltBosse\DB\DB;
 Use HoltBosse\Form\Input;
+Use Respect\Validation\Validator as v;
 
 // get data for view/page combination
 //CMS::pprint_r (CMS::Instance()->page);
@@ -11,7 +12,7 @@ Use HoltBosse\Form\Input;
 $view_config = CMS::Instance()->page->view_configuration_object;
 $tag_id = Content::get_config_value ($view_config, 'blogtag');
 $articles_per_page = Content::get_config_value ($view_config, 'articles_per_page') ?? 999;
-$cur_page = Input::getvar('page') ? Input::getvar('page') : 1; // always make sure we get page number for blog
+$cur_page = Input::getvar('page', v::IntVal(), 1); // always make sure we get page number for blog
 
 
 if (CMS::Instance()->uri_segments) {

--- a/src/corecontrollers/image/controller.php
+++ b/src/corecontrollers/image/controller.php
@@ -18,11 +18,11 @@ $dbInstance = DB::getInstance();
 // handle list api request
 if ($segments[1]=='list_images') {
 	header('Content-Type: application/json; charset=utf-8');
-	$mimetypes = array_filter(explode(',',Input::getvar('mimetypes','STRING')));
-	$searchtext = Input::getvar('searchtext','STRING');
-	$images_per_page = Input::getvar('images_per_page','INT') ?? 50;
-	$page = Input::getvar('page','INT') ?? 1;
-	$tags = Input::getvar("tags");
+	$mimetypes = array_filter(explode(',',Input::getvar('mimetypes',v::StringVal(),''))); // array_filter ensures empty array if mimetypes is null
+	$searchtext = Input::getvar('searchtext',v::StringVal(),'');
+	$images_per_page = Input::getvar('images_per_page',v::IntVal(),50);
+	$page = Input::getvar('page',v::IntVal(),1);
+	$tags = Input::getvar("tags", v::StringVal(), null);
 	if ($searchtext=='null') {
 		$searchtext=null;
 	}


### PR DESCRIPTION
does what it says on the tin. addresses all input::getvar calls not handled in https://github.com/HoltBosse/Alba/pull/670 - does NOT address any input::getvar with RAW, thats for a follow up pr as is json fields

commits: 
* handles as the switch to validators. also fixes a fair few search fields in the cms with chars that can be html encoded
* removes backtick usage for shell exec as thats depreciated in upcoming php 8.5 - saw it, was trival and knocked it out (sorry not really on topic for this pr)
* fixes bug added in https://github.com/HoltBosse/Alba/pull/670 only triggered if you have user list fields and search for something with no result .... also not on topic for this pr

