### PR TITLE
bug: escape back ticks in rich content

### DIFF
--- a/src/Fields/Rich/Rich.php
+++ b/src/Fields/Rich/Rich.php
@@ -347,7 +347,7 @@ class Rich extends Field {
 						editorProps: {
 							transformPastedHTML: html => stripClassAttributes(html),
 						},
-						content: `<?php echo $this->default; ?>`,
+						content: `<?php echo str_replace("`", "\`", $this->default); ?>`,
 					});
 
 					console.log(editorInstance);


### PR DESCRIPTION
does what it says on the tin