### PR TITLE
feat: only allow content types to show on certain domains

### DIFF
--- a/src/Core/Content.php
+++ b/src/Core/Content.php
@@ -78,6 +78,21 @@ class Content {
 		return array_keys(self::$controllerRegistry);
 	}
 
+	public static function isAccessibleOnDomain(int $content_type_id, ?int $domain_index = NULL): bool {
+		if($domain_index===NULL) {
+			$domain_index = CMS::getDomainIndex($_SERVER["HTTP_HOST"]);
+		}
+
+		$location = Content::get_content_location($content_type_id);
+		$custom_fields = JSON::load_obj_from_file(Content::getContentControllerPath($location) . '/custom_fields.json');
+		if (isset($custom_fields->domains)) {
+			if (!in_array($domain_index, $custom_fields->domains)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
 	public static function get_table_name_for_content_type(int $type_id): string {
 		$location = Content::get_content_location($type_id);
 		$custom_fields = JSON::load_obj_from_file(Content::getContentControllerPath($location) . '/custom_fields.json');

--- a/src/admin/controllers/content/views/action/model.php
+++ b/src/admin/controllers/content/views/action/model.php
@@ -15,6 +15,10 @@ if (!$content_type) {
 	CMS::Instance()->queue_message('Unknown content type','danger', $_SERVER['HTTP_REFERER']);
 }
 
+if(!Content::isAccessibleOnDomain($content_type)) {
+	CMS::raise_404();
+}
+
 $location = Content::get_content_location($content_type);
 $custom_fields = JSON::load_obj_from_file(Content::getContentControllerPath($location) . '/custom_fields.json');
 $table_name = "controller_" . $custom_fields->id ;

--- a/src/admin/controllers/content/views/all/model.php
+++ b/src/admin/controllers/content/views/all/model.php
@@ -20,6 +20,10 @@ if (sizeof($segments)>3) {
 	CMS::show_error('Cannot determine content type to show');
 }
 
+if(!Content::isAccessibleOnDomain($content_type_filter)) {
+	CMS::raise_404();
+}
+
 $contentTypeTableRecord = DB::fetch("SELECT * FROM content_types WHERE id=?", $content_type_filter);
 if(!$contentTypeTableRecord) {
 	CMS::raise_404();

--- a/src/admin/controllers/content/views/edit/model.php
+++ b/src/admin/controllers/content/views/edit/model.php
@@ -77,6 +77,10 @@ if (sizeof($segments)==4 && is_numeric($segments[2]) && is_numeric($segments[3])
 	exit(0);
 }
 
+if(!Content::isAccessibleOnDomain($content_type)) {
+	CMS::raise_404();
+}
+
 // update CMS instance with this content information
 // this allows custom form fields etc to easily access information such as
 // content id/type

--- a/src/admin/controllers/content/views/order/model.php
+++ b/src/admin/controllers/content/views/order/model.php
@@ -17,6 +17,10 @@ if (!is_numeric($content_type)) {
     CMS::show_error('Invalid content type');
 }
 
+if(!Content::isAccessibleOnDomain($content_type)) {
+	CMS::raise_404();
+}
+
 $location = Content::get_content_location($content_type);
 $custom_fields = JSON::load_obj_from_file(Content::getContentControllerPath($location) . '/custom_fields.json');
 $content_list_fields = [];

--- a/src/admin/templates/clean/navigation.php
+++ b/src/admin/templates/clean/navigation.php
@@ -1,6 +1,7 @@
 <?php
 
 Use HoltBosse\DB\DB;
+Use HoltBosse\Alba\Core\{CMS, Content};
 
 $navigation = [
     "system"=>[
@@ -36,7 +37,21 @@ $navigation = [
         "type"=>"addition_menu",
         "menu"=>[
             "label"=>"content",
-            "links"=>DB::fetchAll("SELECT title, CONCAT('/admin/content/all/', id) FROM content_types", [], ["mode"=>PDO::FETCH_KEY_PAIR]),
+            "links"=>array_filter(
+                array_map(
+                    function($input) {
+                        if(Content::isAccessibleOnDomain($input[0]->id)) {
+                            return $input[0]->link;
+                        } else {
+                            return null;
+                        }
+                    },
+                    DB::fetchAll("SELECT title, CONCAT('/admin/content/all/', id) AS link, controller_location, id FROM content_types", [], ["mode"=>PDO::FETCH_GROUP])
+                ),
+                function($input) {
+                    return !is_null($input);
+                }
+            ),
         ]
     ],
     "widgets"=>[


### PR DESCRIPTION
allows certain content types to be locked to certain domains in respective admins
(landing this first, widgets next)

SaaS here we come.....