### PR TITLE
chore: extend phpmailers class rather than using internally

### DIFF
--- a/src/Core/Mail.php
+++ b/src/Core/Mail.php
@@ -18,7 +18,7 @@ class Mail extends PHPMailer {
 
 	// Legacy API: store addresses for backwards compatibility
 	public function addAddress($address, $name='') {
-		$this->legacy_to[] = true;
+		$this->legacy_to = true;
 		return parent::addAddress($address, $name);
 	}
 


### PR DESCRIPTION
does what it says on the tin while keeping backwards compat. allows using additionally phpmailer methods without needing wrapper functions added here or completely using phpmailer from scratch.