### PR TITLE
chore: remove plugins dropdown and just make it a link

### DIFF
--- a/src/admin/templates/clean/navigation.php
+++ b/src/admin/templates/clean/navigation.php
@@ -80,14 +80,10 @@ $navigation = [
         ]
     ],
     "plugins"=>[
-        "type"=>"addition_menu",
-        "menu"=>[
+        "type"=>"addition_link",
+        "link"=>[
             "label"=>"plugins",
-            "links"=>array_merge(
-                DB::fetchAll("SELECT title, CONCAT('/admin/plugins/edit/', id) FROM plugins", [], ["mode"=>PDO::FETCH_KEY_PAIR]),
-                ["hr"=>"hr"],
-                ["all plugins"=>"/admin/plugins/show"],
-            )
+            "url"=>"/admin/plugins/show",
         ]
     ],
     "tags"=>[


### PR DESCRIPTION
no one cares about plugins, and the list just gets longer

also in no other place do we have "content items" in the menu