### PR TITLE
feat: on content, tags, categories tell the user which fields failed instead of an opaque error

### DIFF
--- a/src/admin/controllers/categories/views/edit/model.php
+++ b/src/admin/controllers/categories/views/edit/model.php
@@ -82,11 +82,28 @@ if ($required_details_form->isSubmitted()) {
 			}
 		}
 		else {
-			CMS::Instance()->queue_message('Invalid form','danger',$_SERVER['REQUEST_URI']);	
+			$badFields = $custom_fields_form->getFailedValidationFields();
+
+			$niceBadFields = array_map(function($field) use ($custom_fields_form) {
+				return $custom_fields_form->fields[$field]->label !='' ? $custom_fields_form->fields[$field]->label : $custom_fields_form->fields[$field]->name;
+			}, $badFields);
+
+			$niceBadFields = sizeof($niceBadFields) > 0 ? $niceBadFields : ["Unknown fields"];
+
+			CMS::Instance()->queue_message('Invalid form (fields: ' . implode(', ', $niceBadFields) . ')','danger',$_SERVER['REQUEST_URI']);	
 		}
 	}
 	else {
-		CMS::Instance()->queue_message('Invalid form','danger',$_SERVER['REQUEST_URI']);	
+		$badFields = $required_details_form->getFailedValidationFields();
+		//CMS::pprint_r ($badFields);
+
+		$niceBadFields = array_map(function($field) use ($required_details_form) {
+			return $required_details_form->fields[$field]->label !='' ? $required_details_form->fields[$field]->label : $required_details_form->fields[$field]->name;
+		}, $badFields);
+
+		$niceBadFields = sizeof($niceBadFields) > 0 ? $niceBadFields : ["Unknown fields"];
+
+		CMS::Instance()->queue_message('Invalid form (fields: ' . implode(', ', $niceBadFields) . ')','danger',$_SERVER['REQUEST_URI']);	
 	}
 	//CMS::Instance()->queue_message('content saved','success',$_ENV["uripath"] . '/admin/content/show');
 }

--- a/src/admin/controllers/content/views/edit/model.php
+++ b/src/admin/controllers/content/views/edit/model.php
@@ -145,12 +145,25 @@ if ($required_details_form->isSubmitted()) {
 			CMS::Instance()->queue_message($msg, 'success', $redirect_to);
 		}
 		else {
-			CMS::Instance()->queue_message('Invalid form','danger',$_SERVER['HTTP_REFERER']);
+			CMS::Instance()->queue_message('Failed to save Content','danger',$_SERVER['HTTP_REFERER']);
 		}
 		
 	}
 	else {
-		CMS::Instance()->queue_message('Invalid form','danger');	
+		$requiredBadFields = $required_details_form->getFailedValidationFields();
+		$contentBadFields = $content_form->getFailedValidationFields();
+
+		$requiredNiceBadFields = array_map(function($field) use ($required_details_form) {
+			return $required_details_form->fields[$field]->label !='' ? $required_details_form->fields[$field]->label : $required_details_form->fields[$field]->name;
+		}, $requiredBadFields);
+		$contentNiceBadFields = array_map(function($field) use ($content_form) {
+			return $content_form->fields[$field]->label !='' ? $content_form->fields[$field]->label : $content_form->fields[$field]->name;
+		}, $contentBadFields);
+
+		$allNiceBadFields = array_merge($requiredNiceBadFields, $contentNiceBadFields);
+		$allNiceBadFields = sizeof($allNiceBadFields) > 0 ? $allNiceBadFields : ["Unknown fields"];
+
+		CMS::Instance()->queue_message('Invalid form (fields: ' . implode(', ', $allNiceBadFields) . ')','danger');	
 	}
 	//CMS::Instance()->queue_message('content saved','success',$_ENV["uripath"] . '/admin/content/show');
 }

--- a/src/admin/controllers/redirects/views/edit/model.php
+++ b/src/admin/controllers/redirects/views/edit/model.php
@@ -75,12 +75,20 @@ if ($required_details_form->isSubmitted()) {
 			CMS::Instance()->queue_message($msg, 'success', $redirect_to);
 		}
 		else {
-			CMS::Instance()->queue_message('Invalid form','danger',$_SERVER['HTTP_REFERER']);
+			CMS::Instance()->queue_message('Failed to save redirect','danger',$_SERVER['HTTP_REFERER']);
 		}
 		
 	}
 	else {
-		CMS::Instance()->queue_message('Invalid form','danger',$_SERVER['REQUEST_URI']);	
+		$badFields = $required_details_form->getFailedValidationFields();
+
+		$niceBadFields = array_map(function($field) use ($required_details_form) {
+			return $required_details_form->fields[$field]->label !='' ? $required_details_form->fields[$field]->label : $required_details_form->fields[$field]->name;
+		}, $badFields);
+
+		$niceBadFields = sizeof($niceBadFields) > 0 ? $niceBadFields : ["Unknown fields"];
+
+		CMS::Instance()->queue_message('Invalid form (fields: ' . implode(', ', $niceBadFields) . ')','danger',$_SERVER['REQUEST_URI']);	
 	}
 	//CMS::Instance()->queue_message('content saved','success',$_ENV["uripath"] . '/admin/content/show');
 }

--- a/src/admin/controllers/tags/views/edit/model.php
+++ b/src/admin/controllers/tags/views/edit/model.php
@@ -77,11 +77,27 @@ if ($required_details_form->isSubmitted()) {
 			}
 		}
 		else {
-			CMS::Instance()->queue_message('Invalid field form','danger',$_SERVER['REQUEST_URI']);	
+			$badFields = $custom_fields_form->getFailedValidationFields();
+
+			$niceBadFields = array_map(function($field) use ($custom_fields_form) {
+				return $custom_fields_form->fields[$field]->label !='' ? $custom_fields_form->fields[$field]->label : $custom_fields_form->fields[$field]->name;
+			}, $badFields);
+
+			$niceBadFields = sizeof($niceBadFields) > 0 ? $niceBadFields : ["Unknown fields"];
+
+			CMS::Instance()->queue_message('Invalid field form (fields: ' . implode(', ', $niceBadFields) . ')','danger',$_SERVER['REQUEST_URI']);	
 		}
 	}
 	else {
-		CMS::Instance()->queue_message('Invalid form','danger',$_SERVER['REQUEST_URI']);	
+		$badFields = $required_details_form->getFailedValidationFields();
+
+		$niceBadFields = array_map(function($field) use ($required_details_form) {
+			return $required_details_form->fields[$field]->label !='' ? $required_details_form->fields[$field]->label : $required_details_form->fields[$field]->name;
+		}, $badFields);
+
+		$niceBadFields = sizeof($niceBadFields) > 0 ? $niceBadFields : ["Unknown fields"];
+
+		CMS::Instance()->queue_message('Invalid form (fields: ' . implode(', ', $niceBadFields) . ')','danger',$_SERVER['REQUEST_URI']);	
 	}
 	//CMS::Instance()->queue_message('tag saved','success',$_ENV["uripath"] . '/admin/tags/show');
 }


### PR DESCRIPTION
does what it says on the tin

content for some reason requires double save to see the message, but does kick you back, others dont for some reason. seems unrelated to this pr, but something that should be looked into