### PR TITLE
bug: fix css not getting added if field is in a repeatable before hand, but the plus is not yet clicked

### DIFF
--- a/src/Fields/Image/Image.php
+++ b/src/Fields/Image/Image.php
@@ -32,6 +32,7 @@ class Image extends Field {
 		(new CssFile())->loadFromConfig((object)[
             "filePath"=>__DIR__ . "/untrusted.css",
             "injectIntoHead"=>false,
+			"renderOnce"=>$this->in_repeatable_form ?? false,
         ])->display();
 		
 		echo "<div class='field " . ($this->required ? "required" : "") . "'>";

--- a/src/Fields/PickerOrdered/PickerOrdered.php
+++ b/src/Fields/PickerOrdered/PickerOrdered.php
@@ -25,6 +25,7 @@ class PickerOrdered extends Field {
 			(new CssFile())->loadFromConfig((object)[
 				"filePath"=>__DIR__ . "/style.css",
 				"injectIntoHead"=>false,
+				"renderOnce"=>$this->in_repeatable_form ?? false,
 			])->display();
                 ?>
                 

--- a/src/Fields/Rich/Rich.php
+++ b/src/Fields/Rich/Rich.php
@@ -21,6 +21,7 @@ class Rich extends Field {
 					(new CssFile())->loadFromConfig((object)[
 						"filePath"=>__DIR__ . "/style.css",
 						"injectIntoHead"=>false,
+						"renderOnce"=>$this->in_repeatable_form ?? false,
 					])->display();
 				?>
 				<div style="display: none;">


### PR DESCRIPTION
does what it says on the tin

yes, this means that if non repeatables are used and the same field is on the page 5 times, its duplicated (only once for loaded from save content items)

a better way would be to head inject so the css is always on the page, however that comes with its own problems as head_entries isnt a thing on core controllers, fake files. so leaving that a problem for future me to solve