### PR TITLE
feat: add js user_actions

### DIFF
--- a/src/Core/Actions.php
+++ b/src/Core/Actions.php
@@ -3,6 +3,8 @@ namespace HoltBosse\Alba\Core;
 
 Use HoltBosse\DB\DB;
 Use HoltBosse\Form\Input;
+Use Respect\Validation\Validatable;
+Use Respect\Validation\Validator as v;
 Use \DateTime;
 Use \stdClass;
 
@@ -76,6 +78,54 @@ class Actions {
         }
 
         return $id;
+    }
+
+    public static function isApiAccessEnabledForType(string $type): bool {
+        $actionClass = self::getActionClass($type);
+        if ($actionClass === null || !class_exists($actionClass)) {
+            return false;
+        }
+
+        return $actionClass::isApiAccessEnabled();
+    }
+
+    public static function getActionDataSchemaForType(string $type): Validatable {
+        $actionClass = self::getActionClass($type);
+        if ($actionClass === null || !class_exists($actionClass)) {
+            return v::alwaysInvalid();
+        }
+
+        return $actionClass::getActionDataSchema();
+    }
+
+    public static function isApiAccessEnabled(): bool {
+        return false;
+    }
+
+    public static function getActionDataSchema(): Validatable {
+        return v::AlwaysInvalid();
+    }
+
+    public static function insertCsrfTokenForType(string $type): void {
+        $actionClass = self::getActionClass($type);
+        if ($actionClass === null || !class_exists($actionClass)) {
+            throw new \Exception("Unknown action type: $type");
+        }
+
+        $_SESSION["alba_action_csrf_tokens"] = $_SESSION["alba_action_csrf_tokens"] ?? [];
+        
+        $token = $_SESSION["alba_action_csrf_tokens"][$type] ?? bin2hex(random_bytes(32));
+        $_SESSION["alba_action_csrf_tokens"][$type] = $token;
+
+        echo "<script type='module'>window.albaActionCsrf = window.albaActionCsrf || {}; window.albaActionCsrf['$type'] = '$token';</script>";
+    }
+
+    public static function validateApiCsrfTokenForType(string $type, ?string $token): bool {
+        if (!isset($_SESSION["alba_action_csrf_tokens"][$type])) {
+            return false;
+        }
+
+        return hash_equals($_SESSION["alba_action_csrf_tokens"][$type], $token ?? '');
     }
 
     public static function add_action_details(string $actionid, stdClass $details): void {

--- a/src/corecontrollers/api/controller.php
+++ b/src/corecontrollers/api/controller.php
@@ -1,6 +1,7 @@
 <?php
 
 Use HoltBosse\Alba\Core\CMS;
+Use HoltBosse\Alba\Core\Actions;
 Use HoltBosse\Form\Input;
 Use Respect\Validation\Validator as v;
 
@@ -13,6 +14,102 @@ $response = [
 ];
 
 $segments = CMS::Instance()->uri_segments;
+
+if(sizeof($segments) == 3 && $segments[1] == "actions" && $segments[2] == "add_action") {
+    $stockErrorMsg = "invalid action request";
+
+    $type = Input::getVar('type', v::stringType()->notEmpty(), null);
+    $actionJson = Input::getVar('action', v::stringType()->notEmpty()->json(), null);
+
+    if($type === null || $actionJson === null) {
+        echo json_encode([
+            "data"=>[],
+            "success"=>false,
+            "msg"=>$_ENV["debug"]==="true" ? "invalid action request" : $stockErrorMsg,
+        ]);
+        exit();
+    }
+
+    $type = strtolower(trim((string) $type));
+
+    try {
+        $actionData = json_decode((string) $actionJson, false, 512, JSON_THROW_ON_ERROR);
+    } catch (\JsonException $exception) {
+        echo json_encode([
+            "data"=>[],
+            "success"=>false,
+            "msg"=>$_ENV["debug"]==="true" ? "invalid action json" : $stockErrorMsg,
+        ]);
+        exit();
+    }
+
+    if(!v::objectType()->validate($actionData)) {
+        echo json_encode([
+            "data"=>[],
+            "success"=>false,
+            "msg"=>$_ENV["debug"]==="true" ? "invalid action request" : $stockErrorMsg,
+        ]);
+        exit();
+    }
+
+    if(!v::in(Actions::getActionTypes())->validate($type)) {
+        echo json_encode([
+            "data"=>[],
+            "success"=>false,
+            "msg"=>$_ENV["debug"]==="true" ? "unknown action type" : $stockErrorMsg,
+        ]);
+        exit();
+    }
+
+    if(!Actions::isApiAccessEnabledForType($type)) {
+        echo json_encode([
+            "data"=>[],
+            "success"=>false,
+            "msg"=>$_ENV["debug"]==="true" ? "action type not enabled for api access" : $stockErrorMsg,
+        ]);
+        exit();
+    }
+
+    $csrfToken = Input::getVar("csrf_$type", v::stringType()->notEmpty(), null);
+
+    if(!Actions::validateApiCsrfTokenForType($type, $csrfToken)) {
+        echo json_encode([
+            "data"=>[],
+            "success"=>false,
+            "msg"=>$_ENV["debug"]==="true" ? "invalid csrf token" : $stockErrorMsg,
+        ]);
+        exit();
+    }
+
+    $schema = Actions::getActionDataSchemaForType($type);
+
+    if(!$schema->validate($actionData)) {
+        echo json_encode([
+            "data"=>[],
+            "success"=>false,
+            "msg"=>$_ENV["debug"]==="true" ? "action data failed schema validation" : $stockErrorMsg,
+        ]);
+        exit();
+    }
+
+    try {
+        $actionId = Actions::add_action($type, $actionData);
+    } catch (\Throwable $exception) {
+        echo json_encode([
+            "data"=>[],
+            "success"=>false,
+            "msg"=>$_ENV["debug"]==="true" ? "failed to add action" : $stockErrorMsg,
+        ]);
+        exit();
+    }
+
+    echo json_encode([
+        "data"=>[],
+        "success"=>true,
+        "msg"=>"action added",
+    ]);
+    exit();
+}
 
 if(sizeof($segments)==2 && $segments[1]=="parsedown") {
 

--- a/src/corecontrollers/js/js/actions.js
+++ b/src/corecontrollers/js/js/actions.js
@@ -1,0 +1,40 @@
+class Actions {
+    constructor() {
+        console.log("Actions initialized");
+    }
+
+    static async add_action(type, action) {
+        const basePath = typeof window !== "undefined" && window.uripath ? window.uripath : "";
+        const normalizedType = String(type || "").trim().toLowerCase();
+        const csrfEntry = typeof window !== "undefined" ? window.albaActionCsrf[normalizedType] : null;
+
+        if (!csrfEntry || typeof csrfEntry !== "string") {
+            throw new Error(`Missing CSRF token for action type: ${normalizedType}`);
+        }
+
+        const formData = new FormData();
+        formData.append("type", normalizedType);
+        formData.append("action", JSON.stringify(action));
+        formData.append(`csrf_${normalizedType}`, csrfEntry);
+
+        const response = await fetch(`${basePath}/api/actions/add_action`, {
+            method: "POST",
+            body: formData,
+        });
+
+        let payload = {};
+        try {
+            payload = await response.json();
+        } catch (_error) {
+            throw new Error("Unable to parse add_action response");
+        }
+
+        if (!response.ok || !payload.success) {
+            throw new Error(payload.msg || "Failed to add action");
+        }
+
+        return payload;
+    }
+}
+
+export default Actions;


### PR DESCRIPTION
does what it says on the tin

sample usage
```php
<?php
use HoltBosse\Alba\Core\{CMS, Actions};

Actions::insertCsrfTokenForType("jsupdate");

?>

<script type="module">
    import Actions from "/js/actions.js";

    await Actions.add_action("jsupdate", {
        "name": "test",
        "value": "hello world",
    }).then((response) => {
        console.log("jsupdate action response:", response);
    }).catch((error) => {
        console.error("Error dispatching jsupdate action:", error);
    });

    console.log("jsupdate action dispatched");
</script>
```

sample action that supports this

```php
<?php
namespace Wouldnt\You\Like\To\Know\Actions\JsUpdate;

Use HoltBosse\Alba\Core\{Actions, CMS};
Use HoltBosse\DB\DB;
Use Respect\Validation\Validator as v;
Use Respect\Validation\Validatable;

class JsUpdate extends Actions {

    public function display(): void {
        CMS::pprint_r("helloooo");
    }
    
    public static function isApiAccessEnabled(): bool {
        //for example you can login gate here if you care
        return true;
    }

    public static function getActionDataSchema(): Validatable {
        return v::allOf(
            v::objectType(),
            v::attribute('name', v::stringType()->notEmpty()),
            v::attribute('value', v::stringType()->notEmpty()),
            v::callback(function($data) {
                //check that there are no extra properties on the object other than name and value
                $allowedProperties = ['name', 'value'];
                foreach ($data as $key => $value) {
                    if (!in_array($key, $allowedProperties)) {
                        return false;
                    }
                }
                return true;
            })
        );
    }
}
```

