### PR TITLE
feat: add objection kv options to widgets

### DIFF
--- a/src/Core/Widget.php
+++ b/src/Core/Widget.php
@@ -14,6 +14,7 @@ class Widget {
 	public mixed $type = null;
 	public ?int $state = null;
 	public mixed $options = null;
+	public stdClass $objectOptions;
 	public ?string $note = null;
 	public mixed $ordering = null;
 	public mixed $position_control = null;
@@ -191,6 +192,7 @@ class Widget {
 			$this->note = $info->note;
 			$this->ordering = $info->ordering;
 			$this->options = json_decode($info->options);
+			$this->objectOptions = (object) array_combine(array_column($this->options, 'name'), array_column($this->options, 'value'));
 			$this->position_control = $info->position_control;
 			$this->global_position = $info->global_position;
 			$this->page_list = explode(',', $info->page_list);

--- a/src/Widgets/FormInstance/FormInstance.php
+++ b/src/Widgets/FormInstance/FormInstance.php
@@ -7,16 +7,13 @@ Use HoltBosse\DB\DB;
 
 class FormInstance extends Widget {
 	public function render(): void {
-		$normalizedOptions = array_combine(array_column($this->options, 'name'), array_column($this->options, 'value'));
-		//echo $normalizedOptions["forminstance"];
-
-        if(!is_numeric($normalizedOptions["forminstance"])) {
+        if(!is_numeric($this->objectOptions->forminstance)) {
             throw new \Exception("FormInstance widget requires a valid form instance ID as 'forminstance' option.");
         }
 
-        $formDetails = DB::fetch("SELECT * FROM form_instances WHERE id=? AND state>=0", [$normalizedOptions["forminstance"]]);
+        $formDetails = DB::fetch("SELECT * FROM form_instances WHERE id=? AND state>=0", [$this->objectOptions->forminstance]);
 
-        $form = new Form($_ENV["root_path_to_forms"] . "/forms/form_instance_" . $normalizedOptions["forminstance"] . ".json");
+        $form = new Form($_ENV["root_path_to_forms"] . "/forms/form_instance_" . $this->objectOptions->forminstance . ".json");
 
         if($form->isSubmitted()) {
             $form->setFromSubmit();

--- a/src/Widgets/Html/Html.php
+++ b/src/Widgets/Html/Html.php
@@ -5,7 +5,6 @@ Use HoltBosse\Alba\Core\Widget;
 
 class Html extends Widget {
 	public function render(): void {
-		$normalizedOptions = array_combine(array_column($this->options, 'name'), array_column($this->options, 'value'));
-		echo $normalizedOptions["markup"];
+		echo $this->objectOptions->markup;
 	}
 }


### PR DESCRIPTION
saves us for doing $nromalizedOptions in all our code. plus is an object rather than array which avoids array weirdness